### PR TITLE
The analyzer detected an error that has to do with allocating and fre…

### DIFF
--- a/Compiler/compiler.cpp
+++ b/Compiler/compiler.cpp
@@ -376,7 +376,7 @@ Compiler::StaticType Compiler::FindNameAsStatic(const Str& name, Oop& literal, b
 				char szCaption[256];
 				::LoadString(GetResLibHandle(), IDR_COMPILER, szCaption, sizeof(szCaption)-1);
 				int answer = ::MessageBox(NULL, msg, szCaption, MB_YESNOCANCEL|MB_ICONQUESTION|MB_TASKMODAL);
-				delete msg;
+				delete[] msg;
 				
 				switch(answer)
 				{


### PR DESCRIPTION
The analyzer detected an error that has to do with allocating and freeing memory using inconsistent techniques.
When calling operator "new []" to allocate memory, it must be freed with operator "delete []".