### PR TITLE
Warning No. 3: V701 realloc() possible leak: when realloc() fails in …

### DIFF
--- a/Compiler/compiler.cpp
+++ b/Compiler/compiler.cpp
@@ -2908,6 +2908,7 @@ POTE Compiler::ParseByteArray()
 	//
 	int maxelemcount=128; // A convenient start size though we can expand beyond this if necessary
 	BYTE* elems=static_cast<BYTE*>(malloc(maxelemcount*sizeof(BYTE)));
+	BYTE* elemstemp=static_cast<BYTE*>(malloc(maxelemcount*sizeof(BYTE)));
 	int elemcount=0;
 
 	int start = ThisTokenRange().m_start;
@@ -2919,7 +2920,12 @@ POTE Compiler::ParseByteArray()
 		{
 			_ASSERTE(maxelemcount > 0);
 			maxelemcount *= 2;
-			elems = (BYTE*)realloc(elems, maxelemcount*sizeof(BYTE));
+			//when realloc() fails in allocating memory, original pointer 'elems' is lost. 
+			// assigning realloc() to a temporary pointer.
+			elemstemp = (BYTE*)realloc(elems, maxelemcount*sizeof(BYTE));
+			if (elemstemp != NULL) {
+				elems = elemstemp;
+			}
 		}
 		
 		switch(ThisToken()) 


### PR DESCRIPTION
Warning No. 3: V701 realloc() possible leak: when realloc() fails in allocating memory, original pointer 'elems' is lost. Consider assigning realloc() to a temporary pointer. compiler.cpp 2922

This code is potentially dangerous: we recommend using a separate variable to store the return result of function realloc(). The realloc() function is used to change the size of a memory block. If such change is impossible for the moment, it will return a null pointer. The problem is that pointer ptr, referring to this memory block, may get lost when using constructs like "ptr = realloc(ptr, ...)".