### PR TITLE
Cleanup runtime error when assigning to a smaller container

### DIFF
--- a/Compiler/compiler.h
+++ b/Compiler/compiler.h
@@ -144,8 +144,8 @@ private:
 	int RemoveInstruction(int pos);
 	int GenByte(BYTE value, BYTE flags, LexicalScope* pScope);
 	int GenData(BYTE value);
-	int GenInstruction(BYTE basic, BYTE offset=0);
-	int GenInstructionExtended(BYTE basic, BYTE extension);
+	int GenInstruction(BYTE basic, int offset=0);
+	int GenInstructionExtended(BYTE basic, int extension);
 	int GenLongInstruction(BYTE basic, WORD extension);
 	void UngenInstruction(int pos);
 	void UngenData(int pos);
@@ -471,11 +471,11 @@ inline void Compiler::UngenData(int pos)
 
 // Insert an instruction at the code pointer, returning the position at which
 // the instruction was inserted.
-inline int Compiler::GenInstruction(BYTE basic, BYTE offset)
+inline int Compiler::GenInstruction(BYTE basic, int offset)
 {
-	_ASSERTE(offset == 0 || (basic+offset) < FirstDoubleByteInstruction);
+	_ASSERTE((offset == 0) || ((0 <= offset) && (offset <= 0xFF) && ((basic+offset) < FirstDoubleByteInstruction)));
 	_ASSERTE(m_pCurrentScope != NULL);
-	return GenByte(basic + offset, BYTECODE::IsOpCode, m_pCurrentScope);
+	return GenByte(basic + (offset & 0xFF), BYTECODE::IsOpCode, m_pCurrentScope);
 }
 
 inline int Compiler::GenNop()


### PR DESCRIPTION
On my local build this passes all the tests with the Runtime configuration.
From my understanding of the compiler behavior, adding the mask (x & 0xFF) does not impact performance since the value is immediately subject to a cast that would do the same thing. This just makes it explicit to avoid the runtime error.
This does expose a possible issue (to be filed separately) in Compiler::GenInstructionExtended().