### PR TITLE
Generate debug information in release configuration

### DIFF
--- a/Compiler/Compiler.vcxproj
+++ b/Compiler/Compiler.vcxproj
@@ -98,9 +98,6 @@
       <OutputFile>$(TargetPath)</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <ModuleDefinitionFile>.\Compiler.def</ModuleDefinitionFile>
-      <GenerateDebugInformation>false</GenerateDebugInformation>
-      <GenerateMapFile>false</GenerateMapFile>
-      <MapExports>false</MapExports>
       <SubSystem>Windows</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
@@ -108,6 +105,7 @@
       <DataExecutionPrevention />
       <ImportLibrary>.\Release/DolphinCR006.lib</ImportLibrary>
       <ProgramDatabaseFile />
+      <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='VM Debug|Win32'">

--- a/ConsoleStub/Console.vcxproj
+++ b/ConsoleStub/Console.vcxproj
@@ -98,7 +98,7 @@
       <OutputFile>$(OutDir)$(ProjectName)Stub.exe</OutputFile>
       <Version>6.0</Version>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
       <LargeAddressAware>false</LargeAddressAware>
       <TerminalServerAware>false</TerminalServerAware>

--- a/ConsoleToGo/ConsoleToGo.vcxproj
+++ b/ConsoleToGo/ConsoleToGo.vcxproj
@@ -106,7 +106,7 @@
       <DataExecutionPrevention />
       <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
       <ProgramDatabaseFile />
-      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='VM Debug|Win32'">

--- a/DevRes.vcxproj
+++ b/DevRes.vcxproj
@@ -98,7 +98,7 @@
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
       <DataExecutionPrevention />
       <ImportLibrary>.\WinDLL/DolphinDR006.lib</ImportLibrary>
-      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile />
     </Link>
   </ItemDefinitionGroup>

--- a/DolphinSureCrypto/DolphinSureCrypto.vcxproj
+++ b/DolphinSureCrypto/DolphinSureCrypto.vcxproj
@@ -91,7 +91,7 @@
       <DataExecutionPrevention />
       <ImportLibrary>.\Release/DolphinSureCrypto.lib</ImportLibrary>
       <TargetMachine>MachineX86</TargetMachine>
-      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile />
     </Link>
   </ItemDefinitionGroup>

--- a/GUIStub/Stub.vcxproj
+++ b/GUIStub/Stub.vcxproj
@@ -94,7 +94,7 @@
     <Link>
       <AdditionalOptions>/MACHINE:I386 %(AdditionalOptions)</AdditionalOptions>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>
       </ProgramDatabaseFile>
       <SubSystem>Windows</SubSystem>

--- a/InProcStub/InProcStub.vcxproj
+++ b/InProcStub/InProcStub.vcxproj
@@ -104,7 +104,7 @@
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
       <DataExecutionPrevention />
       <ImportLibrary>.\Release/IPDolphin.lib</ImportLibrary>
-      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile />
     </Link>
   </ItemDefinitionGroup>

--- a/InProcToGo/InProcToGo.vcxproj
+++ b/InProcToGo/InProcToGo.vcxproj
@@ -109,7 +109,7 @@
       <DataExecutionPrevention />
       <ImportLibrary>.\Release/IPDolphinToGo.lib</ImportLibrary>
       <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
-      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile />
     </Link>
   </ItemDefinitionGroup>

--- a/Launcher/Dull.vcxproj
+++ b/Launcher/Dull.vcxproj
@@ -100,7 +100,7 @@
       <AdditionalOptions>/MACHINE:I386 %(AdditionalOptions)</AdditionalOptions>
       <OutputFile>$(TargetPath)</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <StackReserveSize>8388608</StackReserveSize>
       <OptimizeReferences>true</OptimizeReferences>

--- a/ToGoStub/GuiToGo.vcxproj
+++ b/ToGoStub/GuiToGo.vcxproj
@@ -102,7 +102,7 @@
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <ModuleDefinitionFile>.\togo.def</ModuleDefinitionFile>
-      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>

--- a/dll.vcxproj
+++ b/dll.vcxproj
@@ -109,7 +109,7 @@
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <IgnoreSpecificDefaultLibraries>rpcndr.lib;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
       <ModuleDefinitionFile>.\VM.def</ModuleDefinitionFile>
-      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>


### PR DESCRIPTION
As part of making the debug configuration work the debug information was removed from the release configuration. This commit restores that setting so that some debugging of the release configuration is possible. Of course, there may be optimizations that make certain variables or code paths less visible but at least the debugger can find the files that link to the sources code.