### PR TITLE
Fix CRT invalid parameter termination on shutdown after saving image

### DIFF
--- a/SaveImage.cpp
+++ b/SaveImage.cpp
@@ -181,8 +181,6 @@ int __stdcall ObjectMemory::SaveImageFile(const char* szFileName, bool bBackup, 
 			stream.setbuf(buf, sizeof(buf));
 
 			bSaved = SaveImage(stream, &header, nRet);
-			stream.close();
-			::_close(fd);
 		}
 
 		// Explicitly free the special MethodContext used for the image stamp

--- a/binstream.h
+++ b/binstream.h
@@ -108,7 +108,7 @@ public:
 	bool attach(int fd, const char* szMode)
 	{
 		close();
-		m_bOwner = false;
+		m_bOwner = true;
 		m_fp = _fdopen(fd, szMode);
 		return m_fp != NULL;
 	}
@@ -140,8 +140,8 @@ public:
 			if (m_bOwner)
 			{
 				fclose(m_fp);
-				m_fp = NULL;
 			}
+			m_fp = NULL;
 		}
 		return *this;
 	}


### PR DESCRIPTION
Fix the abort on shutdown from the CRT that is causing an error exit code if the image has been saved (e.g. on boot). This was caused by not properly closing the stream opened to save the image.