### PR TITLE
Use safe string functions

### DIFF
--- a/Compiler/compiler.cpp
+++ b/Compiler/compiler.cpp
@@ -28,7 +28,7 @@ void __cdecl DolphinTrace(LPCTSTR format, ...)
 	char buf[1024];
 	va_list args;
 	va_start(args, format);
-	/*w*/vsprintf(buf, format, args);
+	/*w*/vsprintf_s(buf, sizeof(buf), format, args);
 	va_end(args);
 	OutputDebugString(buf);
 }

--- a/Compiler/compiler.cpp
+++ b/Compiler/compiler.cpp
@@ -12,6 +12,7 @@ Smalltalk compiler.
 #include "Compiler.h"
 #include <locale.h>
 #include "..\Compiler_i.h"
+#include <Strsafe.h>
 
 // Disable warnings about using SEH
 #pragma warning ( disable : 4509 )
@@ -25,10 +26,10 @@ static int compilationTrace = 0;
 #ifdef USE_VM_DLL
 void __cdecl DolphinTrace(LPCTSTR format, ...) 
 {
-	char buf[1024];
+	TCHAR buf[1024];
 	va_list args;
 	va_start(args, format);
-	/*w*/vsprintf_s(buf, sizeof(buf), format, args);
+	::StringCbVPrintf(buf, sizeof(buf), format, args);
 	va_end(args);
 	OutputDebugString(buf);
 }

--- a/CrashDump.cpp
+++ b/CrashDump.cpp
@@ -13,6 +13,7 @@
 #include "interprt.h"
 #include "VMExcept.h"
 #include "RegKey.h"
+#include <Strsafe.h>
 
 static const DWORD DefaultStackDepth = 300;
 static const DWORD DefaultWalkbackDepth = static_cast<DWORD>(-1);
@@ -239,7 +240,7 @@ void __cdecl DebugCrashDump(LPCTSTR szFormat, ...)
 
 	va_list args;
 	va_start(args, szFormat);
-	::wvsprintf(buf, szFormat, args);
+	::StringCbVPrintf(buf, sizeof(buf), szFormat, args);
 	va_end(args);
 
 	DWORD dwArgs[1];
@@ -289,7 +290,7 @@ void __stdcall DebugDump(LPCTSTR szFormat, ...)
 
 	va_list args;
 	va_start(args, szFormat);
-	::wvsprintf(buf, szFormat, args);
+	::StringCbVPrintf(buf, sizeof(buf), szFormat, args);
 	va_end(args);
 
 	tracelock lock(TRACESTREAM);

--- a/fatalerror.cpp
+++ b/fatalerror.cpp
@@ -69,7 +69,7 @@ LPSTR __stdcall GetErrorText(DWORD win32ErrorCode)
 void __stdcall vtrace(const char* szFormat, va_list args)
 {
 	char buf[1024];
-	::vsprintf(buf, szFormat, args);
+	::vsprintf_s(buf, sizeof(buf), szFormat, args);
 	::OutputDebugString(buf);
 }
 


### PR DESCRIPTION
Address one of the new warnings from VS 2015.