### PR TITLE
Fix Compiler::GenPopAndStoreTemp() triggers assert in Debug #19

### DIFF
--- a/Compiler/Compiler.vcxproj
+++ b/Compiler/Compiler.vcxproj
@@ -133,7 +133,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
       <BrowseInformation>true</BrowseInformation>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>EnableAllWarnings</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <CompileAs>Default</CompileAs>
       <Optimization>Disabled</Optimization>
@@ -141,6 +141,7 @@
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <SmallerTypeCheck>true</SmallerTypeCheck>
+      <SDLCheck>true</SDLCheck>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/Compiler/LexicalScope.h
+++ b/Compiler/LexicalScope.h
@@ -212,7 +212,7 @@ public:
 	//////////////////////////////////////////////
 	// Accessing
 
-	int	GetEstimatedDistance() const;
+	int GetEstimatedDistance() const;
 	int GetActualDistance() const;
 
 	TempVarDecl* GetActualDecl() const
@@ -324,10 +324,10 @@ private:
 	const LexicalScope& operator=(const LexicalScope&);
 
 public:
-	LexicalScope(LexicalScope* pOuter, int nStart) : m_pOuter(pOuter), 
+	LexicalScope(LexicalScope* pOuter, int nStart, bool bOptimized) : m_pOuter(pOuter), 
 				m_nArgs(0), m_nStackSize(0), m_nSharedTemps(0),
 				m_initialIP(-1), m_finalIP(-1),
-				m_bIsEmptyBlock(false), m_bIsOptimizedBlock(false), m_bHasFarReturn(false), 
+				m_bIsEmptyBlock(false), m_bIsOptimizedBlock(bOptimized), m_bHasFarReturn(false),
 				m_bRefersToSelf(false),	m_bRefsOuterTemps(false),
 				m_textRange(nStart, -1), m_oteBlockLiteral(NULL)
 	{

--- a/Compiler/compiler.h
+++ b/Compiler/compiler.h
@@ -121,7 +121,7 @@ private:
 	POTE InternSymbol(const Str&) const;
 
 	// Lookup
-	bool FindNameAsSpecialMessage(const Str&, int& index) const;
+	int FindNameAsSpecialMessage(const Str&) const;
 	bool IsPseudoVariable(const Str&) const;
 	int FindNameAsInstanceVariable(const Str&) const;
 	TempVarRef* AddTempRef(const Str& strName, VarRefType refType, const TEXTRANGE& refRange, int expressionEnd);
@@ -135,15 +135,14 @@ private:
 	int GetCodeSize() const;
 	int AddToFrameUnconditional(Oop object, const TEXTRANGE&);
 	int AddToFrame(Oop object, const TEXTRANGE&);
-	int AddConstantsToFrame(Oop object);
 	int AddStringToFrame(POTE string, const TEXTRANGE&);
 	BYTECODES::iterator InsertByte(int pos, BYTE value, BYTE flags, LexicalScope* pScope);
 	void RemoveByte(int pos);
 	int RemoveInstruction(int pos);
 	int GenByte(BYTE value, BYTE flags, LexicalScope* pScope);
 	int GenData(BYTE value);
-	int GenInstruction(BYTE basic, int offset=0);
-	int GenInstructionExtended(BYTE basic, int extension);
+	int GenInstruction(BYTE basic, BYTE offset=0);
+	int GenInstructionExtended(BYTE basic, BYTE extension);
 	int GenLongInstruction(BYTE basic, WORD extension);
 	void UngenInstruction(int pos);
 	void UngenData(int pos);
@@ -152,7 +151,7 @@ private:
 	int GenDup();
 	int GenPopStack();
 	
-	void GenInteger(long val, const TEXTRANGE&);
+	void GenInteger(int val, const TEXTRANGE&);
 	Oop GenNumber(const char* textvalue, const TEXTRANGE&);
 	void GenNumber(Oop, const TEXTRANGE&);
 	void GenConstant(int index);
@@ -171,16 +170,15 @@ private:
 	void GenPushSelf();
 	void GenPushVariable(const Str&, const TEXTRANGE&);
 	int GenPushTemp(TempVarRef*);
-	int GenPushInstVar(int index);
+	int GenPushInstVar(BYTE index);
 	void GenPushStaticVariable(const Str&, const TEXTRANGE&);
 
 	void GenPopAndStoreTemp(TempVarRef*);
-	void GenPopAndStoreInstVar(int index);
 
 	int GenStore(const Str&, const TEXTRANGE&, int assignedExpressionStop);
 	int GenStoreTemp(TempVarRef*);
-	int GenStoreInstVar(int index);
-	int GenStaticStore(const Str&, int, const TEXTRANGE&, int assignedExpressionStop);
+	int GenStoreInstVar(BYTE index);
+	int GenStaticStore(const Str&, const TEXTRANGE&, int assignedExpressionStop);
 
 	int GenReturn(BYTE retOp);
 	int GenFarReturn();
@@ -295,7 +293,7 @@ private:
 	TempVarRef* AddOptimizedTemp(const Str& name, const TEXTRANGE& range=TEXTRANGE());
 	void RenameTemporary(int temporary, const char* newName, const TEXTRANGE& range);
 	void CheckTemporaryName(const Str&, const TEXTRANGE&, bool isArg);
-	void PushNewScope(int textStart=-1);
+	void PushNewScope(int textStart, bool bOptimized=false);
 	void PushOptimizedScope(int textStart=-1);
 	void PopScope(int textStop);
 	void PopOptimizedScope(int textStop);
@@ -469,11 +467,11 @@ inline void Compiler::UngenData(int pos)
 
 // Insert an instruction at the code pointer, returning the position at which
 // the instruction was inserted.
-inline int Compiler::GenInstruction(BYTE basic, int offset)
+inline int Compiler::GenInstruction(BYTE basic, BYTE offset)
 {
-	_ASSERTE((offset == 0) || ((0 <= offset) && (offset <= 0xFF) && ((basic+offset) < FirstDoubleByteInstruction)));
+	_ASSERTE(offset == 0 || ((int)basic+offset) < FirstDoubleByteInstruction);
 	_ASSERTE(m_pCurrentScope != NULL);
-	return GenByte(basic + (offset & 0xFF), BYTECODE::IsOpCode, m_pCurrentScope);
+	return GenByte(basic + offset, BYTECODE::IsOpCode, m_pCurrentScope);
 }
 
 inline int Compiler::GenNop()

--- a/Compiler/optimizer.cpp
+++ b/Compiler/optimizer.cpp
@@ -2213,7 +2213,8 @@ void Compiler::FixupTempRef(BYTECODES::iterator it)
 
 	case tvtShared:
 		{
-			unsigned outer = pVarRef->GetActualDistance();
+			int outer = pVarRef->GetActualDistance();
+			_ASSERTE(outer >= 0 && outer < 256);
 			TempVarDecl* pDecl = pVarRef->GetDecl();
 			_ASSERTE(pDecl == pVarRef->GetActualDecl());
 			if (outer > 0)

--- a/DolphinVM.sln
+++ b/DolphinVM.sln
@@ -5,6 +5,9 @@ MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "VM", "dll.vcxproj", "{382ABBF3-B32D-4D77-B303-346AA146921C}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Launcher", "Launcher\Dull.vcxproj", "{A8454911-DE25-451D-AC38-1B6B058C050D}"
+	ProjectSection(ProjectDependencies) = postProject
+		{35EB6247-4F53-4605-AA04-A9310AB3235B} = {35EB6247-4F53-4605-AA04-A9310AB3235B}
+	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Compiler", "Compiler\Compiler.vcxproj", "{35EB6247-4F53-4605-AA04-A9310AB3235B}"
 EndProject
@@ -50,6 +53,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{89BB403F-881C-4B73-BA44-50A545697C93}"
 	ProjectSection(SolutionItems) = preProject
 		dolphin.props = dolphin.props
+		dolphin.targets = dolphin.targets
 	EndProjectSection
 EndProject
 Global

--- a/istasm.inc
+++ b/istasm.inc
@@ -850,7 +850,7 @@ GetIPOffsetUsing MACRO tempRegister
 	.ENDIF
 	sub		_IP, tempRegister								;; Convert _IP to offset into object
 	IFDEF _DEBUG
-		.IF (_IP > 4096)
+		.IF (_IP > 8192)
 			int	3											;; Probably a bug - _IP index very large
 		.ENDIF
 	ENDIF


### PR DESCRIPTION
Fix the compiler detecting block nesting too deep on exit parse of
offending block rather than on block open. This stops the compiler
attempting to generate bad instructions.