### PR TITLE
VM app manifest needs updating for win 8.1 and later #49

### DIFF
--- a/Launcher/Dull.rc2
+++ b/Launcher/Dull.rc2
@@ -1,0 +1,60 @@
+//
+// DULL.RC2 - resources Microsoft Visual C++ does not edit directly
+//
+
+#ifdef APSTUDIO_INVOKED
+#error this file is not editable by Microsoft Visual C++
+#endif //APSTUDIO_INVOKED
+
+
+/////////////////////////////////////////////////////////////////////////////
+// Add manually edited resources here...
+
+/////////////////////////////////////////////////////////////////////////////
+// English (United States) resources
+
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
+LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
+#pragma code_page(1252)
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Version
+//
+
+VS_VERSION_INFO VERSIONINFO
+  FILEVERSION DOLPHIN_VERINFO_VERSION
+  PRODUCTVERSION DOLPHIN_VERINFO_VERSION
+  FILEFLAGSMASK 0x3fL
+#ifdef _DEBUG
+  FILEFLAGS 0x23L
+#else
+  FILEFLAGS 0x22L
+#endif
+  FILEOS 0x4L
+  FILETYPE 0x1L
+  FILESUBTYPE 0x0L
+BEGIN
+BLOCK "StringFileInfo"
+	BEGIN
+		BLOCK "040904e4"
+		BEGIN
+			VALUE "CompanyName", "Object Arts Ltd."
+			VALUE "FileDescription", "Dolphin Smalltalk Launcher"
+			VALUE "FileVersion", DOLPHIN_ASSEMBLY_VERSION
+			VALUE "InternalName", "Dolphin"
+			VALUE "LegalCopyright", "Copyright © Object Arts 1997-2016. STS © David Gorisek 2000-2016"
+			VALUE "OriginalFilename", "Dolphin7.exe"
+			VALUE "ProductName", "Dolphin Smalltalk"
+			VALUE "ProductVersion", GIT_TAG
+		END
+	END
+	BLOCK "VarFileInfo"
+	BEGIN
+		VALUE "Translation", 0x409, 1252
+	END
+END
+
+#endif    // English (United States) resources
+
+/////////////////////////////////////////////////////////////////////////////

--- a/Launcher/Dull.vcxproj
+++ b/Launcher/Dull.vcxproj
@@ -53,6 +53,12 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
+    <GenerateManifest>true</GenerateManifest>
+    <EmbedManifest>true</EmbedManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='VM Debug|Win32'">
+    <GenerateManifest>true</GenerateManifest>
+    <EmbedManifest>true</EmbedManifest>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <CustomBuildStep>
@@ -103,11 +109,16 @@
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
       <DataExecutionPrevention />
       <ProgramDatabaseFile />
+      <Version>$(DolphinVersion)</Version>
     </Link>
     <PreBuildEvent>
       <Command>
       </Command>
     </PreBuildEvent>
+    <Manifest>
+      <!-- Ensure that link generate manifest generation merges the project specific manifest, otherwise it is just overwritten -->
+      <InputResourceManifests>$(TargetPath);#1</InputResourceManifests>
+    </Manifest>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='VM Debug|Win32'">
     <CustomBuildStep>
@@ -165,11 +176,16 @@
       <IgnoreSpecificDefaultLibraries>
       </IgnoreSpecificDefaultLibraries>
       <MapExports>true</MapExports>
+      <AssemblyDebug>true</AssemblyDebug>
+      <Version>$(DolphinVersion)</Version>
     </Link>
     <PreBuildEvent>
       <Command>
       </Command>
     </PreBuildEvent>
+    <Manifest>
+      <InputResourceManifests>$(TargetPath);#1</InputResourceManifests>
+    </Manifest>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\fatalerror.cpp">
@@ -196,9 +212,6 @@
     <Image Include="..\Res\flipper.ico" />
   </ItemGroup>
   <ItemGroup>
-    <Manifest Include="..\Res\Dolphin.exe.manifest" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\DevRes.vcxproj">
       <Project>{fab6154d-5e54-4967-b55d-f5aee5dc18f0}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
@@ -213,7 +226,12 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\getVersion.cmd" />
+    <Manifest Include="..\Res\Dolphin.exe.manifest">
+      <FileType>Manifest</FileType>
+      <!-- At the time this manifest is built, the .exe won't contain any manifest resource to merge with -->
+      <InputResourceManifests>
+      </InputResourceManifests>
+    </Manifest>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/Launcher/dull.rc
+++ b/Launcher/dull.rc
@@ -14,56 +14,6 @@
 #undef APSTUDIO_READONLY_SYMBOLS
 
 /////////////////////////////////////////////////////////////////////////////
-// English (United States) resources
-
-#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
-LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
-#pragma code_page(1252)
-
-/////////////////////////////////////////////////////////////////////////////
-//
-// Version
-//
-
-VS_VERSION_INFO VERSIONINFO
- FILEVERSION 2016,7,0,0
- PRODUCTVERSION 2016,7,0,0
- FILEFLAGSMASK 0x3fL
-#ifdef _DEBUG
- FILEFLAGS 0x23L
-#else
- FILEFLAGS 0x22L
-#endif
- FILEOS 0x4L
- FILETYPE 0x1L
- FILESUBTYPE 0x0L
-BEGIN
-    BLOCK "StringFileInfo"
-    BEGIN
-        BLOCK "040904e4"
-        BEGIN
-            VALUE "CompanyName", "Object Arts Ltd."
-            VALUE "FileDescription", "Dolphin Smalltalk Launcher"
-            VALUE "FileVersion", "2016.7.0.0"
-            VALUE "InternalName", "Dolphin"
-            VALUE "LegalCopyright", "Copyright © Object Arts 1997-2016. STS © David Gorisek 2000-2016"
-            VALUE "OriginalFilename", "Dolphin7.exe"
-            VALUE "ProductName", "Dolphin Smalltalk"
-            VALUE "ProductVersion", GIT_TAG
-            VALUE "WARNING", "Please edit this as a text file rather than with the resource editor to preserve GIT_TAG"
-        END
-    END
-    BLOCK "VarFileInfo"
-    BEGIN
-        VALUE "Translation", 0x409, 1252
-    END
-END
-
-#endif    // English (United States) resources
-/////////////////////////////////////////////////////////////////////////////
-
-
-/////////////////////////////////////////////////////////////////////////////
 // English (United Kingdom) resources
 
 #if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENG)
@@ -78,14 +28,6 @@ LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_UK
 // Icon with lowest ID value placed first to ensure application icon
 // remains consistent on all systems.
 !APPLICATION            ICON                    "..\\Res\\Flipper.ico"
-
-
-/////////////////////////////////////////////////////////////////////////////
-//
-// RT_MANIFEST
-//
-
-IDR_MANIFEST            RT_MANIFEST             "..\\res\\dolphin.exe.manifest"
 
 
 #ifdef APSTUDIO_INVOKED
@@ -108,8 +50,7 @@ END
 
 3 TEXTINCLUDE 
 BEGIN
-    "\r\n"
-    "\0"
+    "#include ""dull.rc2""\0"
 END
 
 #endif    // APSTUDIO_INVOKED
@@ -151,8 +92,7 @@ END
 //
 // Generated from the TEXTINCLUDE 3 resource.
 //
-
-
+#include "dull.rc2"
 /////////////////////////////////////////////////////////////////////////////
 #endif    // not APSTUDIO_INVOKED
 

--- a/Launcher/resource.h
+++ b/Launcher/resource.h
@@ -1,8 +1,7 @@
 //{{NO_DEPENDENCIES}}
 // Microsoft Visual C++ generated include file.
-// Used by dull.rc
+// Used by Dull.rc
 //
-#define IDR_MANIFEST                    1
 #define IDP_FAILEDTOMARSHALOUTER        5
 #define IDP_FAILEDTOUNMARSHALOUTER      6
 #define IDP_FAILTOSTARTTHREAD           7

--- a/Res/Dolphin.exe.manifest
+++ b/Res/Dolphin.exe.manifest
@@ -1,22 +1,18 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?> 
-<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0"> 
-<assemblyIdentity 
-version="1.0.0.0" 
-processorArchitecture="X86" 
-name="Object Arts.Dolphin Smalltalk.Dolphin" 
-type="win32" 
-/> 
-<description>Dolphin Smalltalk Development System.</description> 
-<dependency> 
-<dependentAssembly> 
-<assemblyIdentity 
-type="win32" 
-name="Microsoft.Windows.Common-Controls" 
-version="6.0.0.0" 
-processorArchitecture="X86" 
-publicKeyToken="6595b64144ccf1df" 
-language="*" 
-/> 
-</dependentAssembly> 
-</dependency> 
-</assembly> 
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+  <description>Dolphin Smalltalk Development System.</description>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- Windows 10 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+      <!-- Windows 8.1 -->
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+      <!-- Windows Vista -->
+      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
+      <!-- Windows 7 -->
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+      <!-- Windows 8 -->
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+    </application>
+  </compatibility>
+</assembly>

--- a/VMLib/VMLib.vcxproj
+++ b/VMLib/VMLib.vcxproj
@@ -263,7 +263,6 @@
     <ClInclude Include="..\STVirtualObject.h" />
     <ClInclude Include="..\thrdcall.h" />
     <ClInclude Include="..\TraceStream.h" />
-    <ClInclude Include="..\Version.h" />
     <ClInclude Include="..\VMExcept.h" />
     <ClInclude Include="..\VMPointers.h" />
     <ClInclude Include="..\zfbinstream.h" />

--- a/dolphin.targets
+++ b/dolphin.targets
@@ -4,20 +4,32 @@
   <PropertyGroup>
     <VersionHeader>$(IntDir)Version.h</VersionHeader>
   </PropertyGroup>
+  
   <Target Name="GenerateVersionHeader" BeforeTargets="BeforeResourceCompile">
     <Exec Command='git describe --tag > "$(IntDir)version.txt"' Outputs="$(IntDir)version.txt" />
     <ReadLinesFromFile File="$(IntDir)version.txt">
       <Output TaskParameter="Lines" PropertyName="GitTag"/>
     </ReadLinesFromFile>
+    <PropertyGroup>
+	  <DolphinVersion>$([System.Datetime]::Now.Year).$(GitTag.SubString(1, $([MSBuild]::Subtract($(GitTag.IndexOf('-')), 1))))</DolphinVersion>
+    </PropertyGroup>
+	<Message Importance="Normal" Text="Building Dolphin version $(DolphinVersion)" />
     <Delete Files="$(IntDir)version.txt"/>
     <Message Importance="Normal" Text="Generating version.h for tag $(GitTag)..." />
-    <WriteLinesToFile Overwrite="true" File="$(VersionHeader)" Encoding="Ascii" Lines='
+    <WriteLinesToFile Overwrite="true" File="$(VersionHeader)" Encoding="Ascii" Lines="
 // this file generated on $([System.DateTime]::Now)
+#define DOLPHIN_ASSEMBLY_VERSION &quot;$(DolphinVersion)&quot;
+#define DOLPHIN_VERINFO_VERSION $(DolphinVersion.Replace('.',','))
 #if defined(_DEBUG)
-  #define GIT_TAG "$(GitTag) (Debug)"
+  #define GIT_TAG &quot;$(GitTag) (Debug)&quot;
 #else
-  #define GIT_TAG "$(GitTag)"
-#endif' />
+  #define GIT_TAG &quot;$(GitTag)&quot;
+#endif" />
+	<ItemGroup>
+		<Manifest>
+		  <AssemblyIdentity>ObjectArts.DolphinSmalltalk.Dolphin, version=$(DolphinVersion), processorArchitecture=x86, type=win32</AssemblyIdentity>
+		</Manifest>
+	</ItemGroup>
   </Target>
   <Target Name='CleanVersionHeader' AfterTargets='AfterClean'>
     <Delete Files='$(VersionHeader)'/>
@@ -45,5 +57,7 @@
       <ProgramDatabaseFile />
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
+  	<Manifest>
+	</Manifest>
   </ItemDefinitionGroup>
 </Project>


### PR DESCRIPTION
Also pull the version number stored in the fixed version info from
the git tag and merge generated manifest with hand built part.
The version info resource is moved from .rc to .rc2 to stop it being
detokenized by the resource editor.