### PR TITLE
Remove references to deleted file so that build is not dirty

### DIFF
--- a/ConsoleToGo/ConsoleToGo.vcxproj
+++ b/ConsoleToGo/ConsoleToGo.vcxproj
@@ -213,7 +213,6 @@
     <ClInclude Include="..\STMethod.h" />
     <ClInclude Include="..\STMethodContext.h" />
     <ClInclude Include="..\STObject.h" />
-    <ClInclude Include="..\STPoint.h" />
     <ClInclude Include="..\STProcess.h" />
     <ClInclude Include="..\STStackFrame.h" />
     <ClInclude Include="..\STStream.h" />
@@ -237,6 +236,6 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="$(SolutionDir)dolphin.targets"/>
+    <Import Project="$(SolutionDir)dolphin.targets" />
   </ImportGroup>
 </Project>

--- a/InProcToGo/InProcToGo.vcxproj
+++ b/InProcToGo/InProcToGo.vcxproj
@@ -264,7 +264,6 @@
     <ClInclude Include="..\STMethod.h" />
     <ClInclude Include="..\STMethodContext.h" />
     <ClInclude Include="..\STObject.h" />
-    <ClInclude Include="..\STPoint.h" />
     <ClInclude Include="..\STProcess.h" />
     <ClInclude Include="..\STStackFrame.h" />
     <ClInclude Include="..\STStream.h" />

--- a/ToGoLib/ToGoLib.vcxproj
+++ b/ToGoLib/ToGoLib.vcxproj
@@ -316,7 +316,6 @@
     <ClInclude Include="..\STMethod.h" />
     <ClInclude Include="..\STMethodContext.h" />
     <ClInclude Include="..\STObject.h" />
-    <ClInclude Include="..\STPoint.h" />
     <ClInclude Include="..\STProcess.h" />
     <ClInclude Include="..\STStackFrame.h" />
     <ClInclude Include="..\STStream.h" />

--- a/ToGoStub/GuiToGo.vcxproj
+++ b/ToGoStub/GuiToGo.vcxproj
@@ -248,7 +248,6 @@
     <ClInclude Include="..\STMethod.h" />
     <ClInclude Include="..\STMethodContext.h" />
     <ClInclude Include="..\STObject.h" />
-    <ClInclude Include="..\STPoint.h" />
     <ClInclude Include="..\STProcess.h" />
     <ClInclude Include="..\STStackFrame.h" />
     <ClInclude Include="..\STStream.h" />
@@ -293,6 +292,6 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="$(SolutionDir)dolphin.targets"/>
+    <Import Project="$(SolutionDir)dolphin.targets" />
   </ImportGroup>
 </Project>


### PR DESCRIPTION
A file was deleted but still referenced from four projects. This caused Visual Studio to think that the project had changed and needed to be rebuilt. This commit simply removes those file references (and appears to have a couple other cosmetic changes based on re-saving the project.