### PR TITLE
Dolphin issue #144 take 2

### DIFF
--- a/ConsoleToGo/ConsoleToGo.def
+++ b/ConsoleToGo/ConsoleToGo.def
@@ -13,6 +13,8 @@ argv
 StdIn
 StdOut
 StdErr
+IsUserBreakRequested=?IsUserBreakRequested@Interpreter@@CG_NXZ
+
 CompileForClass=_PrimCompileForClass@20
 CompileForEval=_PrimCompileForEval@24
 

--- a/InProcToGo/IPToGo.def
+++ b/InProcToGo/IPToGo.def
@@ -20,6 +20,8 @@ argv
 StdIn
 StdOut
 StdErr
+IsUserBreakRequested=?IsUserBreakRequested@Interpreter@@CG_NXZ
+
 CompileForClass=_PrimCompileForClass@20
 CompileForEval=_PrimCompileForEval@24
 

--- a/Interprt.h
+++ b/Interprt.h
@@ -327,7 +327,7 @@ private:
 	static BOOL __stdcall MsgSendPoll();
 	static BOOL	__stdcall BytecodePoll();
 	static BOOL sampleInput();
-	static bool GetUserInterruptRequested();
+	static bool __stdcall IsUserBreakRequested();
 	
 	static void __fastcall executeNewMethod(MethodOTE* methodOTE, unsigned argCount);
 	static void __fastcall returnValueTo(Oop resultPointer, Oop contextPointer);

--- a/ToGoStub/togo.def
+++ b/ToGoStub/togo.def
@@ -16,8 +16,7 @@ StdIn
 StdOut
 StdErr
 RegisterAsEventSource
-
-; Image expiry mechanism
+IsUserBreakRequested=?IsUserBreakRequested@Interpreter@@CG_NXZ
 
 CompileForClass=_PrimCompileForClass@20
 CompileForEval=_PrimCompileForEval@24

--- a/bytecde.cpp
+++ b/bytecde.cpp
@@ -112,7 +112,7 @@ inline BOOL Interpreter::sampleInput()
 			// running at full tilt it will prevent the idler from signalling
 			// the input semaphore itself.
 			asynchronousSignal(Pointers.InputSemaphore);
-			if (GetUserInterruptRequested())
+			if (IsUserBreakRequested())
 			{
 				#ifdef _DEBUG
 					WarningWithStackTrace("User Interrupt:");
@@ -146,30 +146,27 @@ inline BOOL Interpreter::sampleInput()
 
 #pragma code_seg(INTERP_SEG)
 
-bool Interpreter::GetUserInterruptRequested()
+bool Interpreter::IsUserBreakRequested()
 {
 	// Note that we want to call GetAsyncKeyState for each key to clear the state
 	// so we don't want to early out just because one of the required keys has not
 	// been pressed.
 
 	int hotkey = integerValueOf(Pointers.InterruptHotKey);
-	int vk = hotkey & 0xFF;
+	int vk = hotkey & 0x1FF;
 	bool interrupt = (::GetAsyncKeyState(vk) & 0x8001) != 0;
-	int modifiers = (hotkey & 0xFF00) >> 8;
-	if (modifiers != 0)
+	int modifiers = (hotkey >> 9);
+	if (modifiers & FSHIFT)
 	{
-		if (modifiers & HOTKEYF_SHIFT)
-		{
-			interrupt &= (::GetAsyncKeyState(VK_SHIFT) & 0x8001) != 0;
-		}
-		if (modifiers & HOTKEYF_CONTROL)
-		{
-			interrupt &= (::GetAsyncKeyState(VK_CONTROL) & 0x8001) != 0;
-		}
-		if (modifiers & HOTKEYF_ALT)
-		{
-			interrupt &= (::GetAsyncKeyState(VK_MENU) & 0x8001) != 0;
-		}
+		interrupt &= (::GetAsyncKeyState(VK_SHIFT) & 0x8001) != 0;
+	}
+	if (modifiers & FCONTROL)
+	{
+		interrupt &= (::GetAsyncKeyState(VK_CONTROL) & 0x8001) != 0;
+	}
+	if (modifiers & FALT)
+	{
+		interrupt &= (::GetAsyncKeyState(VK_MENU) & 0x8001) != 0;
 	}
 	return interrupt;
 }

--- a/process.cpp
+++ b/process.cpp
@@ -1708,7 +1708,7 @@ BOOL __fastcall Interpreter::primitiveSampleInterval()
 	ResetInputPollCounter();
 
 	// And ensure pressed bit of async key state is reset
-	GetUserInterruptRequested();
+	IsUserBreakRequested();
 
 	popStack();											// Pop the SmallInteger argument
 	replaceStackTopWith(oldInterval);	// Answer the old interval, and return non-zero to succeed

--- a/vm.def
+++ b/vm.def
@@ -24,6 +24,7 @@ StdIn
 StdOut
 StdErr
 _snprintf
+IsUserBreakRequested=?IsUserBreakRequested@Interpreter@@CG_NXZ
 
 CompileForClass=_PrimCompileForClass@20
 CompileForEval=_PrimCompileForEval@24


### PR DESCRIPTION
Interpretation of accel key code from image config was incorrect.
Export the key press test function so can call image side in idle loop
to interrupt main process blocked on a Semaphore.