### PR TITLE
Ref variable binding for consts unless the value has an immediate form

### DIFF
--- a/Compiler/compiler.h
+++ b/Compiler/compiler.h
@@ -127,7 +127,7 @@ private:
 	TempVarRef* AddTempRef(const Str& strName, VarRefType refType, const TEXTRANGE& refRange, int expressionEnd);
 
 	enum StaticType { STATICCANCEL=-1, STATICNOTFOUND, STATICVARIABLE, STATICCONSTANT };
-	StaticType FindNameAsStatic(const Str&, Oop&, bool autoDefine=false);
+	StaticType FindNameAsStatic(const Str&, POTE&, bool autoDefine=false);
 
 	void WarnIfRestrictedSelector(int start);
 
@@ -156,7 +156,7 @@ private:
 	void GenNumber(Oop, const TEXTRANGE&);
 	void GenConstant(int index);
 	void GenLiteralConstant(Oop object, const TEXTRANGE&);
-	void GenStatic(int index);
+	void GenStatic(const POTE oteStatic, const TEXTRANGE&);
 	
 	int GenMessage(const Str& pattern, int argumentCount, int messageStart);
 
@@ -172,6 +172,9 @@ private:
 	int GenPushTemp(TempVarRef*);
 	int GenPushInstVar(BYTE index);
 	void GenPushStaticVariable(const Str&, const TEXTRANGE&);
+	void GenPushStaticConstant(POTE oteBinding, const TEXTRANGE& range);
+	void GenPushConstant(Oop objectPointer, const TEXTRANGE& range);
+	bool GenPushImmediate(Oop objectPointer, const TEXTRANGE& range);
 
 	void GenPopAndStoreTemp(TempVarRef*);
 

--- a/bytecdes.h
+++ b/bytecdes.h
@@ -133,7 +133,7 @@ enum {
 	SpecialSendAtPut,
 	SpecialSendValue2,
 	SpecialSendBasicNew,
-	SpecialSendYourself,
+	SpecialSendBasicClass,
 	SpecialSendBasicSize,
 	SpecialSendBasicAt,
 	SpecialSendBasicAtPut,
@@ -224,7 +224,7 @@ enum {
 	BlockCopy = FirstMultiByteInstruction,
 	ExLongSend,
 	ExLongSupersend,
-	_UnusedMultiByte
+	ExLongPushImmediate
 };
 
 
@@ -271,13 +271,14 @@ struct BlockCopyExtension
 	BYTE	copiedValuesCount:7;
 };
 
-enum { BlockCopyInstructionSize = 7 };
+enum { PushSmallIntInstructionSize = 5, BlockCopyInstructionSize = 7 };
 
 inline int lengthOfByteCode(BYTE opCode)
 {
 	return opCode < FirstDoubleByteInstruction ? 1 : 
 				opCode < FirstTripleByteInstruction ? 2 : 
 					opCode <  FirstMultiByteInstruction ? 3 : 
-						opCode == BlockCopy ? BlockCopyInstructionSize : 4;
+						opCode == BlockCopy ? BlockCopyInstructionSize : 
+							opCode == ExLongPushImmediate ? PushSmallIntInstructionSize : 4;
 
 }


### PR DESCRIPTION
In D6 I introduced the notion of constant variable bindings, and changed
the way code was compiled such that for any constant the method would
refer to the constant value, rather than the variable binding. This only
really carried any advantage for objects with immediate representations
(i.e. representable in the byte codes, without needing a literal frame
entry, such as nil, true, false, and a range of SmallInteger values). For
all other objects the difference was limited to a storing a constant
object value in the literal frame instead of a variable binding (association)
and there being PushConst instead of PushStatic instructions for that
ref. This has a (probably unmeasurable) perf advantage in avoiding one
level of pointer indirection, but complicates searching for references to
variables in the IDE, and also makes it necessary to recompile any refs
if the "constant" value is changed.
With this change only immediate constant values will be "inlined", and
otherwise the literal frame will reference the variable binding.
A bytecode instruction, ExLongPushImmediate is added to allow the full range
of SmallInteger values to be inlined. This is a 5 byte instruction with
a 32-bit integer stored directly in the 4 bytes following the instruction.
There is no space advantage in this representation but it means that
SmallInteger consts are always stored directly in the
instruction stream, which simplifies some other things. There is also a
small perf gain as the new instruction does not need to load the current
method pointer and indirect off that, and so requires fewer cycles.