### PR TITLE
Ignore new IntelliSense database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ UpgradeLog.htm
 *.aps
 *.opensdf
 *.VC.opendb
+*.VC.db


### PR DESCRIPTION
Since installing VisualStudio Update 2 I find a new file that should be ignored. See http://stackoverflow.com/questions/36407386/what-is-the-vc-db-file-in-visual-studio-projects-and-can-i-safely-delete-it.