### PR TITLE
Compiler temps map scope depth may be wrong for nested full blocks #83 

### DIFF
--- a/Compiler/Compiler.idl
+++ b/Compiler/Compiler.idl
@@ -93,7 +93,6 @@ library CompilerLib
 		CErrMethodTooLarge,
 		CErrTooManyLiterals,
 		CErrBlockNestingTooDeep,
-		CErrBlockArgMissing,
 		CErrBadPools=83,
 		CErrDuplicateTempName=85,
 		CErrDuplicateArgName,

--- a/Compiler/ParseInlinedMessages.cpp
+++ b/Compiler/ParseInlinedMessages.cpp
@@ -672,8 +672,7 @@ TempVarRef* Compiler::AddOptimizedTemp(const Str& tempName, const TEXTRANGE& ran
 {
 	_ASSERTE(m_pCurrentScope->IsOptimizedBlock());
 	TempVarDecl* pDecl = AddTemporary(tempName, range, false);
-	//_ASSERTE(m_pCurrentScope->FindTempRef(pDecl->GetName()) == NULL);
-	pDecl ->BeReadOnly();
+	pDecl->BeReadOnly();
 	return m_pCurrentScope->AddTempRef(pDecl, vrtWrite, range);
 }
 

--- a/Compiler/compiler.cpp
+++ b/Compiler/compiler.cpp
@@ -623,7 +623,6 @@ inline void Compiler::GenPushStaticVariable(const Str& strName, const TEXTRANGE&
 		break;
 
 	case STATICVARIABLE:
-		//_ASSERTE(ObjectMemory::isKindOf(oteBinding, GetVMPointers().ClassVariableBinding));
 		GenStatic(oteStatic, range);
 		break;
 		
@@ -702,7 +701,6 @@ void Compiler::GenPushVariable(const Str& strName, const TEXTRANGE& range)
 void Compiler::GenInteger(int val, const TEXTRANGE& range)
 {
 	// Generates code to push a small integer constant.
-	//_ASSERTE(CanBeSmallInteger(val));
 	if (val >= -1 && val <= 2)
 		GenInstruction(ShortPushZero + val);
 	else if (val >= -128 && val <= 127)
@@ -1047,7 +1045,6 @@ int Compiler::GenMessage(const Str& pattern, int argCount, int messageStart)
 	// It wasn't that simple so we'll need a literal 
 	// symbol in the frame.
 	POTE oteSelector = InternSymbol(pattern);
-	//_ASSERTE(m_piVM->IsImmutable(reinterpret_cast<Oop>(oteSelector)));
 	TEXTRANGE errRange = TEXTRANGE(messageStart, argCount == 0 ? ThisTokenRange().m_stop : LastTokenRange().m_stop);
 	int symbolIndex=AddToFrame(reinterpret_cast<Oop>(oteSelector), errRange);
 	if (symbolIndex < 0)
@@ -3286,7 +3283,6 @@ void Compiler::VerifyTextMap(bool bFinal)
 	{
 		const TEXTMAP& textMap = m_textMaps[i];
 		int ip = textMap.ip;
-		const BYTECODE& bc = m_bytecodes[i];
 		AssertValidIpForTextMapEntry(ip, bFinal);
 	}
 }

--- a/Compiler/compiler.cpp
+++ b/Compiler/compiler.cpp
@@ -110,7 +110,24 @@ Compiler::Compiler() :
 	
 Compiler::~Compiler()
 {
-	Cleanup();
+	// Free scopes
+	{
+		const int count = m_allScopes.size();
+		for (int i = 0; i < count ; i++)
+		{
+			LexicalScope* pScope = m_allScopes[i];
+			delete pScope;
+		}
+	}
+
+	// Free literal frame
+	{
+		const int count = m_literalFrame.size();
+		for (int i = 0; i < count; i++)
+		{
+			m_piVM->RemoveReference(m_literalFrame[i]);
+		}
+	}
 }
 
 inline void Compiler::SetFlagsAndText(FLAGS flags, const char* text, int offset)
@@ -140,40 +157,6 @@ void Compiler::PrepareToCompile(FLAGS flags, const char* compiletext, int offset
 	
 	GetContext(workspacePools);
 }
-
-void Compiler::Cleanup()
-{
-	// Tidy up internal allocations
-	m_instVars.resize(0);
-
-	m_class = 0;
-	m_notifier = 0;
-	m_compilerObject = 0;
-	m_context = 0;
-
-	// Free scopes
-	{
-		const SCOPELIST::iterator loopEnd = m_allScopes.end();
-		for (SCOPELIST::iterator it = m_allScopes.begin(); it != m_allScopes.end(); it++)
-		{
-			LexicalScope* pScope = (*it);
-			delete pScope;
-		}
-		m_allScopes.clear();
-	}
-
-	// Free literal frame
-	{
-		const OOPVECTOR::iterator loopEnd = m_literalFrame.end();
-		for (OOPVECTOR::iterator it=m_literalFrame.begin();it != loopEnd;it++)
-			m_piVM->RemoveReference(*it);
-		m_literalFrame.clear();
-	}
-	
-	m_textMaps.clear();
-	m_bytecodes.clear();
-}
-
 
 Str Compiler::GetNameOfClass(Oop oopClass, bool recurse)
 {
@@ -541,6 +524,7 @@ void Compiler::UngenInstruction(int pos)
 	// Marks the byte at pos as being unwanted by changing it to a Nop
 	if (bc.isJumpSource())
 	{
+		_ASSERTE(bc.target < GetCodeSize());
 		_ASSERTE(static_cast<SWORD>(bc.target) >= 0);
 		m_bytecodes[bc.target].removeJumpTo();
 		bc.makeNonJump();
@@ -551,7 +535,7 @@ void Compiler::UngenInstruction(int pos)
 	bc.byte = Nop;
 	// Also nop-out any data bytes associated with the instruction
 	for (int i=1;i<len;i++)
-		UngenData(pos+i);
+		UngenData(pos+i, bc.pScope);
 }
 
 // Opens up a space at pos in the code array
@@ -572,25 +556,27 @@ void Compiler::InsertByte(int pos, BYTE value, BYTE flags, LexicalScope* pScope)
 
 		// New byte may become jump target
 		// Adjust the jumps providing we are not appending to the end of the code.
-		// Note use of <= because we have inserted an addition bytecode
+		// Note use of <= because we have inserted an additional bytecode
 		for (int i=0; i <= codeSize; i++)
 		{
-			if (m_bytecodes[i].isJumpSource())
+			BYTECODE& bc = m_bytecodes[i];
+			if (bc.isJumpSource())
 			{
-				// This is a jump. Does it cross the boundary
-				if (m_bytecodes[i].target >= pos)
+				_ASSERTE(bc.target < GetCodeSize() - 1);
+
+				// This is a jump. Does it cross the boundary?
+				if (bc.target >= pos)
 				{
-					_ASSERTE(static_cast<SWORD>(m_bytecodes[i].target) >= 0);
-					m_bytecodes[i].target++;
+					bc.target++;
 				}
 			}
 		}
 	
 		// Adjust ip of any TextMaps
-		const TEXTMAPLIST::iterator loopEnd = m_textMaps.end();
-		for (TEXTMAPLIST::iterator it = m_textMaps.begin(); it != loopEnd; it++)
+		const int textMapCount = m_textMaps.size();
+		for (int i = 0; i < textMapCount; i++)
 		{
-			TEXTMAP& textMap = (*it);
+			TEXTMAP& textMap = m_textMaps[i];
 			if (textMap.ip >= pos)
 				textMap.ip++;
 		}
@@ -3251,10 +3237,10 @@ void Compiler::AssertValidIpForTextMapEntry(int ip, bool bFinal)
 		bool isFirstInBlock = prev != NULL && (prev->byte == BlockCopy 
 								|| (bc.pScope == NULL 
 										? bc.byte == Nop && prev != NULL && prev->isUnconditionalJump()
-										: bc.pScope->GetActualScope()->IsBlock() 
-											&& (bc.pScope->GetActualScope()->GetInitialIP() == ip
+										: bc.pScope->GetRealScope()->IsBlock() 
+											&& (bc.pScope->GetRealScope()->GetInitialIP() == ip
 											|| bc.pScope != prev->pScope 
-											|| bc.pScope->GetActualScope() != prev->pScope->GetActualScope())));
+											|| bc.pScope->GetRealScope() != prev->pScope->GetRealScope())));
 		if (bFinal && WantDebugMethod())
 			// If not at the start of a method or block, then a text map entry should only occur after a Break
 			// or (when stripping unreachable code) if the byte immediately follows an unconditional return/jump
@@ -3278,12 +3264,28 @@ void Compiler::VerifyTextMap(bool bFinal)
 {
 	//_CrtCheckMemory();
 	const int size = m_textMaps.size();
-	int arrayIndex = 0;
 	for (int i=0; i<size; i++)
 	{
 		const TEXTMAP& textMap = m_textMaps[i];
 		int ip = textMap.ip;
 		AssertValidIpForTextMapEntry(ip, bFinal);
+	}
+}
+
+void Compiler::VerifyJumps()
+{
+	const int size = GetCodeSize();
+	for (int i = 0; i<size; i++)
+	{
+		const BYTECODE& bc = m_bytecodes[i];
+		if (bc.isJumpSource())
+		{
+			_ASSERTE(bc.isJumpInstruction());
+			_ASSERTE(bc.target >= 0 && bc.target < size);
+			const BYTECODE& target = m_bytecodes[bc.target];
+			_ASSERTE(!target.isData());
+			_ASSERTE(target.jumpsTo > 0);
+		}
 	}
 }
 #endif
@@ -3439,7 +3441,7 @@ STDMETHODIMP_(POTE) Compiler::CompileForClass(IUnknown* piVM, Oop compilerOop, c
 	__try
 	{
 		crtFlag = _CrtSetDbgFlag( _CRTDBG_REPORT_FLAG );
-		_CrtSetDbgFlag( crtFlag | _CRTDBG_DELAY_FREE_MEM_DF /*| _CRTDBG_CHECK_ALWAYS_DF */);
+		_CrtSetDbgFlag( crtFlag /*| _CRTDBG_CHECK_ALWAYS_DF */);
 		
 #ifdef USE_VM_DLL
 		prevLocale = setlocale(LC_ALL, NULL);
@@ -3461,10 +3463,10 @@ STDMETHODIMP_(POTE) Compiler::CompileForClass(IUnknown* piVM, Oop compilerOop, c
 			
 			m_piVM->StorePointerWithValue(&(result.fields[0]), Oop(methodPointer));
 			
-			if (flags & TextMap)
+			if (WantTextMap())
 				m_piVM->StorePointerWithValue(&(result.fields[1]), Oop(GetTextMapObject()));
 			
-			if (flags & TempsMap)
+			if (WantTempsMap())
 				m_piVM->StorePointerWithValue(&(result.fields[2]), Oop(GetTempsMapObject()));
 		}
 		__except(DolphinExceptionFilter(m_piVM, GetExceptionInformation()))
@@ -3487,7 +3489,6 @@ STDMETHODIMP_(POTE) Compiler::CompileForClass(IUnknown* piVM, Oop compilerOop, c
 			free(prevLocale);
 		}
 #endif
-		Cleanup();
 		_CrtSetDbgFlag(crtFlag);
 	}
 	
@@ -3530,10 +3531,10 @@ STDMETHODIMP_(POTE) Compiler::CompileForEval(IUnknown* piVM, Oop compilerOop, co
 			
 			m_piVM->StorePointerWithValue(&(result.fields[0]), Oop(methodPointer));
 			
-			if (flags & TextMap)
+			if (WantTextMap())
 				m_piVM->StorePointerWithValue(&(result.fields[1]), Oop(GetTextMapObject()));
 			
-			if (flags & TempsMap)
+			if (WantTempsMap())
 				m_piVM->StorePointerWithValue(&(result.fields[2]), Oop(GetTempsMapObject()));
 		}
 		__except(DolphinExceptionFilter(m_piVM, GetExceptionInformation()))
@@ -3556,7 +3557,6 @@ STDMETHODIMP_(POTE) Compiler::CompileForEval(IUnknown* piVM, Oop compilerOop, co
 			free(prevLocale);
 		}
 #endif
-		Cleanup();
 	}
 	
 	CHECKREFERENCES

--- a/Compiler/stdafx.h
+++ b/Compiler/stdafx.h
@@ -43,4 +43,6 @@
 	#define INLINE				__forceinline
 #endif
 
+// Turn off iterator debugging as it makes the compiler very slow on large methods in debug builds
+#define _HAS_ITERATOR_DEBUGGING 0
 #include <vector>

--- a/LoadImage.cpp
+++ b/LoadImage.cpp
@@ -318,8 +318,6 @@ HRESULT ObjectMemory::LoadObject(OTE* ote, ibinstream& imageFile, const ImageHea
 	}
 	else
 	{
-		ASSERT(byteSize >= SizeOfPointers(0) && byteSize < 1024*1024);
-
 		if (byteSize <=	MaxSmallObjectSize)
 		{
 			// Allocate from one of the memory pools
@@ -336,12 +334,9 @@ HRESULT ObjectMemory::LoadObject(OTE* ote, ibinstream& imageFile, const ImageHea
 
 	markObject(ote);
 	VariantObject* obj = static_cast<VariantObject*>(ote->m_location);
-	//obj->m_size = byteSize;
-	//if (!imageFile.read(obj->m_fields, byteSize-sizeof(MWORD)))
 	if (!imageFile.read(obj->m_fields, byteSize))
 		return ImageReadError(imageFile);
 
-	//nRead += byteSize-sizeof(MWORD);
 	nRead += byteSize;
 	FixupObject(ote, oldLocation, pHeader);
 

--- a/SaveImage.cpp
+++ b/SaveImage.cpp
@@ -243,11 +243,7 @@ bool __stdcall ObjectMemory::SaveObjects(obinstream& imageFile, const ImageHeade
 				dwDataSize += sizeof(VirtualObjectHeader);
 			}
 
-			// Debug check to catch corruption - it is of course permitted for Object to be 
-			// greater than 512k in size, just unlikely
 			MWORD bytesToWrite = ote->sizeOf();
-			HARDASSERT(bytesToWrite < 512*1024);
-
 			imageFile.write(obj, bytesToWrite);
 
 			if (imageFile.good() == 0)

--- a/SaveImage.cpp
+++ b/SaveImage.cpp
@@ -246,7 +246,7 @@ bool __stdcall ObjectMemory::SaveObjects(obinstream& imageFile, const ImageHeade
 			// Debug check to catch corruption - it is of course permitted for Object to be 
 			// greater than 512k in size, just unlikely
 			MWORD bytesToWrite = ote->sizeOf();
-			ASSERT(bytesToWrite < 512*1024);
+			HARDASSERT(bytesToWrite < 512*1024);
 
 			imageFile.write(obj, bytesToWrite);
 

--- a/VMPointers.h
+++ b/VMPointers.h
@@ -183,7 +183,7 @@ struct VMPointers //: public Object
 	// 127..150
 
 	HandleOTE* MsgWndHandle;							// 127
-	BehaviorOTE* ClassIDispatch;						// 128 - POTE of Semaphore currently in use by timer
+	BehaviorOTE* ClassIDispatch;						// 128
 	Oop ImageVersionMajor;								// 129 - MS word of image version
 	Oop	ImageVersionMinor;								// 130 - LS word of image version
 	Oop InterruptHotKey;								// 131 - HOTKEYF_XXX|VK_XXX value to be used for interrupt key, e.g. Ctrl+Break = VK_CANCEL

--- a/alloc.cpp
+++ b/alloc.cpp
@@ -452,7 +452,7 @@ void ObjectMemory::FixedSizePool::morePages()
 	m_pFreePages = reinterpret_cast<Link*>(pStart);
 
 	#ifdef _DEBUG
-//		m_nPages++;
+	//		m_nPages++;
 	#endif
 }
 

--- a/decode.cpp
+++ b/decode.cpp
@@ -120,6 +120,18 @@ inline ostream& operator<<(ostream& stream, const Class& cl)
 	return stream << reinterpret_cast<const VariantCharOTE*>(cl.m_name);
 }
 
+
+ostream& operator<<(ostream& stream, const ClassOTE* ote)
+{
+	if (ote->isNil()) return stream << "nil";
+
+	if (!(ObjectMemory::isBehavior(Oop(ote) && !ObjectMemory::isAMetaclass(reinterpret_cast<const OTE*>(ote)))))
+		// Expected a Class Oop, but got something else
+		return stream << "**Non-class: " << reinterpret_cast<const OTE*>(ote) << "**";
+	else
+		return stream << *ote->m_location;
+}
+
 ostream& operator<<(ostream& stream, const MetaClass& meta)
 {
 	return stream << meta.m_instanceClass << " class";
@@ -792,22 +804,11 @@ void Interpreter::StackTraceOn(ostream& dc, StackFrame* pFrame, unsigned depth)
 
 void Interpreter::WarningWithStackTraceBody(const char* warningCaption, StackFrame* pFrame)
 {
-	ostringstream dc;
-	
-	dc << endl << warningCaption << endl;
-	StackTraceOn(dc, pFrame);
-	dc << endl;
+	TRACESTREAM << endl << warningCaption << endl;
+	StackTraceOn(TRACESTREAM, pFrame);
+	TRACESTREAM << endl;
 //		decodeMethod((pFrame?pFrame:m_registers.m_pActiveFrame)->m_method, dc);
-	dc << endl << ends;
-	string strTrace = dc.str();
-	
-#if defined(AFX)
-	if (::MessageBox(NULL, LPCTSTR(strTrace.c_str()), warningCaption, MB_OKCANCEL|MB_SYSTEMMODAL|MB_ICONSTOP) == IDCANCEL)
-		DEBUGBREAK();
-#else
-	TRACESTREAM << strTrace;
-	TRACESTREAM.flush();
-#endif
+	TRACESTREAM << endl << flush;
 }
 
 void Interpreter::WarningWithStackTrace(const char* warningCaption, StackFrame* pFrame)

--- a/objmem.h
+++ b/objmem.h
@@ -57,7 +57,6 @@ public:
 	static HRESULT InitializeImage();
 	static void InitializeMemoryManager();
 	static void Terminate();
-	static void Reset();		// Cleans up and reinits
 
 	// Object Pointer access
 	static Oop fetchPointerOfObject(MWORD fieldIndex, PointersOTE* ote);


### PR DESCRIPTION
Compiler changes to fix issue affecting debugging of code involving nested full blocks (i.e. those that assign to temps declared in outer scopes)