### PR TITLE
Compiler not optimising return of SmallIntegers > 16 bits #87

### DIFF
--- a/Compiler/bytecode.h
+++ b/Compiler/bytecode.h
@@ -239,7 +239,7 @@ struct BYTECODE
 
 	inline bool isPush() const
 	{
-		return isShortPush() || isExtendedPush() ||	isDoubleExtendedPush();
+		return isShortPush() || isExtendedPush() ||	isDoubleExtendedPush() || byte == ExLongPushImmediate;
 	}
 
 	INLINE bool isExtendedStore() const

--- a/Compiler/compiler.cpp
+++ b/Compiler/compiler.cpp
@@ -773,6 +773,12 @@ Oop Compiler::IsPushLiteral(int pos) const
 		// Remember x86 is little endian
 		return IntegerObjectOf(SWORD(m_bytecodes[pos+1].byte | (m_bytecodes[pos+2].byte << 8)));
 
+	case ExLongPushImmediate:
+		return IntegerObjectOf(static_cast<SDWORD>((m_bytecodes[pos+ExLongPushImmediateInstructionSize-1].byte) << 24
+			| (m_bytecodes[pos + ExLongPushImmediateInstructionSize - 2].byte << 16)
+			| (m_bytecodes[pos + ExLongPushImmediateInstructionSize - 3].byte << 8)
+			| m_bytecodes[pos + ExLongPushImmediateInstructionSize - 4].byte));
+
 	case PushConst:
 		return m_literalFrame[m_bytecodes[pos+1].byte];
 

--- a/Compiler/optimizer.cpp
+++ b/Compiler/optimizer.cpp
@@ -1968,6 +1968,24 @@ POTE Compiler::NewMethod()
 		else
 			AddToFrameUnconditional(IntegerObjectOf(immediateWord), TEXTRANGE());
 	}
+	else if (byte1 == ExLongPushImmediate && m_bytecodes[ExLongPushImmediateInstructionSize].byte == ReturnMessageStackTop)
+	{
+		_ASSERTE(GetCodeSize() >= 4);
+		_ASSERTE(m_bytecodes[ExLongPushImmediateInstructionSize].isOpCode());
+		MakeQuickMethod(hdr, PRIMITIVE_RETURN_LITERAL_ZERO);
+		_ASSERTE(m_primitiveIndex == 0);
+		SDWORD immediateValue = static_cast<SDWORD>((m_bytecodes[ExLongPushImmediateInstructionSize-1].byte << 24) 
+									| (m_bytecodes[ExLongPushImmediateInstructionSize - 2].byte << 16) 
+									| (m_bytecodes[ExLongPushImmediateInstructionSize - 3].byte << 8) 
+									| m_bytecodes[ExLongPushImmediateInstructionSize - 4].byte);
+		if (GetLiteralCount() > 0)
+		{
+			m_literalFrame.push_back(m_literalFrame[0]);
+			m_literalFrame[0] = IntegerObjectOf(immediateValue);
+		}
+		else
+			AddToFrameUnconditional(IntegerObjectOf(immediateValue), TEXTRANGE());
+	}
 	else if (byte1 == PushChar && byte3 == ReturnMessageStackTop)
 	{
 		_ASSERTE(GetCodeSize() == 3 || !WantOptimize());


### PR DESCRIPTION
Recently introduced ExLongPushImmediate instruction was not accounted
for in optimisation of push immediate instructions.