### PR TITLE
Target 10.0.14393.0 Windows SDK

### DIFF
--- a/Compiler/Compiler.vcxproj
+++ b/Compiler/Compiler.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{35EB6247-4F53-4605-AA04-A9310AB3235B}</ProjectGuid>
     <RootNamespace>Compiler</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/ConsoleStub/Console.vcxproj
+++ b/ConsoleStub/Console.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{F6BBF41C-E4E0-4514-BA19-E248DE206820}</ProjectGuid>
     <RootNamespace>Console</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
@@ -180,6 +180,6 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="$(SolutionDir)dolphin.targets"/>
+    <Import Project="$(SolutionDir)dolphin.targets" />
   </ImportGroup>
 </Project>

--- a/ConsoleToGo/ConsoleToGo.vcxproj
+++ b/ConsoleToGo/ConsoleToGo.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{714480A5-0779-4C59-8A08-856E5C34AC37}</ProjectGuid>
     <RootNamespace>ConsoleToGo</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/DevRes.vcxproj
+++ b/DevRes.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{FAB6154D-5E54-4967-B55D-F5AEE5DC18F0}</ProjectGuid>
     <RootNamespace>DevRes</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/DolphinLib.vcxproj
+++ b/DolphinLib.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{241D4E3E-44C0-40B7-BE1B-5249916FE631}</ProjectGuid>
     <RootNamespace>DolphinLib</RootNamespace>
     <Keyword>MakeFileProj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/DolphinSureCrypto/DolphinSureCrypto.vcxproj
+++ b/DolphinSureCrypto/DolphinSureCrypto.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{6D089C23-9091-47DB-B092-93D387425DC0}</ProjectGuid>
     <RootNamespace>DolphinSureCrypto</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/GUIStub/Stub.vcxproj
+++ b/GUIStub/Stub.vcxproj
@@ -14,7 +14,7 @@
     <ProjectName>GUIStub</ProjectName>
     <ProjectGuid>{47007458-C534-493F-9A4C-936E5E0C91C8}</ProjectGuid>
     <RootNamespace>GUIStub</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/InProcStub/InProcStub.vcxproj
+++ b/InProcStub/InProcStub.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{CD85B8FA-6C9E-45C0-AFC8-0A79A7E5D0F7}</ProjectGuid>
     <RootNamespace>InProcStub</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/InProcToGo/InProcToGo.vcxproj
+++ b/InProcToGo/InProcToGo.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{90C32F90-C0B1-46FE-BACE-FB6566EB6F3C}</ProjectGuid>
     <RootNamespace>InProcToGo</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/Launcher/Dull.vcxproj
+++ b/Launcher/Dull.vcxproj
@@ -14,7 +14,7 @@
     <ProjectName>Launcher</ProjectName>
     <ProjectGuid>{A8454911-DE25-451D-AC38-1B6B058C050D}</ProjectGuid>
     <RootNamespace>Launcher</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/ToGoLib/ToGoLib.vcxproj
+++ b/ToGoLib/ToGoLib.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{50AB410B-7D13-43FF-B426-FB02CA3FEF86}</ProjectGuid>
     <RootNamespace>VMLib</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/ToGoStub/GuiToGo.vcxproj
+++ b/ToGoStub/GuiToGo.vcxproj
@@ -14,7 +14,7 @@
     <ProjectName>GUIToGo</ProjectName>
     <ProjectGuid>{12B536BA-143E-4F38-BD96-77B35467DB13}</ProjectGuid>
     <RootNamespace>ToGoStub</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/VMLib/VMLib.vcxproj
+++ b/VMLib/VMLib.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{BC5D162D-46BC-42CF-85DB-CB715EE8517E}</ProjectGuid>
     <RootNamespace>VMLib</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/WINHEAP.H
+++ b/WINHEAP.H
@@ -138,6 +138,8 @@ extern int      __sbh_cntHeaderList;      /*  count of entries defined */
 extern PHEADER      __sbh_pHeaderDefer;
 extern int          __sbh_indGroupDefer;
 
+/************************ BEGIN BSM MODIFICATION ******************************
+* We don't need these
 _Check_return_ extern size_t  __cdecl _get_sb_threshold(void);
 extern int     __cdecl _set_sb_threshold(_In_ size_t _Size);
 
@@ -151,6 +153,7 @@ _Check_return_ _Ret_opt_bytecap_(_NewSize) extern void *  __cdecl _expand_base(_
 
 _Check_return_ extern size_t  __cdecl _msize_base(_In_ void * _Memory);
 _Check_return_ extern size_t  __cdecl _aligned_msize_base(_In_ void * _Memory, _In_ size_t _Alignment, _In_ size_t _Offset);
+************************ END BSM MODIFICATION ********************************/
 
 _Check_return_ extern int     __cdecl __sbh_heap_init(_In_ size_t _Threshold);
 

--- a/dll.vcxproj
+++ b/dll.vcxproj
@@ -14,7 +14,7 @@
     <ProjectName>VM</ProjectName>
     <ProjectGuid>{382ABBF3-B32D-4D77-B303-346AA146921C}</ProjectGuid>
     <RootNamespace>VM</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">


### PR DESCRIPTION
Update to later Windows SDK. This is the SDK that is installed by default by VS2015 Update 3. The benefit of the change is that it is not necessary to change the default installation options for new VS installs. The downside is that if you have an older installation that you have not updated, you will need to update to U3.