### PR TITLE
Fix Compiler generates mismatched text maps for methods containing empty blocks #96

### DIFF
--- a/Compiler/compiler.cpp
+++ b/Compiler/compiler.cpp
@@ -3248,9 +3248,17 @@ void Compiler::AssertValidIpForTextMapEntry(int ip, bool bFinal)
 											|| bc.pScope != prev->pScope 
 											|| bc.pScope->GetRealScope() != prev->pScope->GetRealScope())));
 		if (bFinal && WantDebugMethod())
+		{
 			// If not at the start of a method or block, then a text map entry should only occur after a Break
 			// or (when stripping unreachable code) if the byte immediately follows an unconditional return/jump
-			_ASSERTE(ip == 0 || isFirstInBlock || bc.isConditionalJump() || (prev->isBreak() || (!bc.isJumpTarget() && (prev->isReturn() || prev->isLongJump()))));
+			_ASSERTE(ip == 0 
+				|| isFirstInBlock 
+				|| bc.isConditionalJump()
+				|| (bc.isShortPushConst() && IsBlock(m_literalFrame[bc.indexOfShortPushConst()]))
+				|| (bc.byte == PushConst && IsBlock(m_literalFrame[m_bytecodes[ip + 1].byte]))
+				|| (prev->isBreak() || (!bc.isJumpTarget() && (prev->isReturn() || prev->isLongJump()))));
+		}
+
 		_ASSERTE(bc.isSend()
 			|| bc.isConditionalJump()
 			|| bc.isStore()

--- a/Compiler/optimizer.cpp
+++ b/Compiler/optimizer.cpp
@@ -2500,19 +2500,21 @@ void Compiler::MakeCleanBlockAt(int i)
 	// with a push of a literal block we store in the frame, and a jump
 	// over the blocks bytecodes.
 
-	POTE blockPointer = GetVMPointers().EmptyBlock;
+	const VMPointers& vmPointers = GetVMPointers();
+	POTE blockPointer = WantDebugMethod() ? vmPointers.EmptyDebugBlock : vmPointers.EmptyBlock;
 	bool isEmptyBlock = pScope->IsEmptyBlock();
-	bool useEmptyBlock = isEmptyBlock && blockPointer != Nil() && !WantDebugMethod();
+	bool useEmptyBlock = isEmptyBlock && blockPointer != Nil() 
+		// We don't want to generate empty block form for the empty block itself
+		&& this->GetTextLength() != 2;
 
 	if (useEmptyBlock)
 	{
 		_ASSERTE(!firstInBlock.isJumpTarget());
 		_ASSERTE(!secondInBlock.isJumpTarget());
-		_ASSERTE(!WantDebugMethod());
 	}
 	else
 	{
-		blockPointer = m_piVM->NewObjectWithPointers(GetVMPointers().ClassBlockClosure, 
+		blockPointer = m_piVM->NewObjectWithPointers(vmPointers.ClassBlockClosure, 
 		((sizeof(STBlockClosure)
 			-sizeof(Oop)	// Deduct dummy literal frame entry (arrays cannot be zero sized in IDL)
 //			-sizeof(ObjectHeader)	// Deduct size of head which NewObjectWithPointers includes implicitly

--- a/VMPointers.h
+++ b/VMPointers.h
@@ -71,7 +71,7 @@ struct VMPointers //: public Object
 	StringOTE* LineDelimString;							// 5
 	ArrayOTE* EmptyArray;								// 6
 	BlockOTE* EmptyBlock;								// 7
-	Oop _reserved8;										// 8
+	BlockOTE* EmptyDebugBlock;							// 8
 
 	POTE SmalltalkDictionary;							// 9	- Pointer to Smalltalk variable (a variable binding)
 	SchedulerOTE* Scheduler;							// 10	- Pointer to Processor object


### PR DESCRIPTION
Add a debug empty block for use in debug methods and ensure that the compiler generates correct text maps for this and the non-debug empty block.