### PR TITLE
Remove unreferenced headers (interlockedops.h) that cause rebuild

### DIFF
--- a/InProcToGo/InProcToGo.vcxproj
+++ b/InProcToGo/InProcToGo.vcxproj
@@ -233,7 +233,6 @@
     <ClInclude Include="..\DolphinSmalltalk_i.h" />
     <ClInclude Include="..\DolphinX.h" />
     <ClInclude Include="..\environ.h" />
-    <ClInclude Include="..\interlockedops.h" />
     <ClInclude Include="..\InterpRegisters.h" />
     <ClInclude Include="..\Interprt.h" />
     <ClInclude Include="..\ist.h" />

--- a/ToGoStub/GuiToGo.vcxproj
+++ b/ToGoStub/GuiToGo.vcxproj
@@ -216,7 +216,6 @@
     <ClInclude Include="..\DolphinSmalltalk_i.h" />
     <ClInclude Include="..\DolphinX.h" />
     <ClInclude Include="..\environ.h" />
-    <ClInclude Include="..\interlockedops.h" />
     <ClInclude Include="..\InterpRegisters.h" />
     <ClInclude Include="..\Interprt.h" />
     <ClInclude Include="..\ist.h" />


### PR DESCRIPTION
Two projects get rebuilt even if there are no changes. This fixes that.