### PR TITLE
Fix some bugs in primitives that are causing intermittent faults in test runs

### DIFF
--- a/ExternalBytes.asm
+++ b/ExternalBytes.asm
@@ -387,10 +387,13 @@ dwordAtPut PROC
 	jz		@F										; No
 
 	; Store down smallInteger value
-	mov		[_SP-OOPSIZE*2], edx					; Overwrite receiver
-	PopStack <2>									; Past failing so pop arg/offset (both SmallIntegers)
+	mov		ecx, edx
 	sar		edx, 1									; Convert from SmallInteger value
 	mov		[eax], edx								; Store down value into object
+	
+	; Past failing so adjust stack (returns the argument)
+	mov		[_SP-OOPSIZE*2], ecx					; Overwrite receiver
+	PopStack <2>									
 	ret
 
 @@:	

--- a/decode.cpp
+++ b/decode.cpp
@@ -8,8 +8,8 @@ Decodes byte codes to stdout
 #include "Ist.h"
 
 #ifndef _DEBUG
-	#pragma optimize("s", on)
-	#pragma auto_inline(off)
+#pragma optimize("s", on)
+#pragma auto_inline(off)
 #endif
 
 #pragma code_seg(DEBUG_SEG)
@@ -46,7 +46,7 @@ void printChars(ostream& stream, const VariantCharOTE* oteChars)
 	unsigned len = oteChars->bytesSize();
 	VariantCharObject* string = oteChars->m_location;
 	unsigned end = min(len, 80);
-	for (unsigned i = 0; i<end; i++)
+	for (unsigned i = 0; i < end; i++)
 	{
 		unsigned char ch = (unsigned char)string->m_characters[i];
 		//if (ch = '\0') break;
@@ -140,7 +140,7 @@ ostream& operator<<(ostream& stream, const ClassOTE* ote)
 {
 	if (ote->isNil()) return stream << "nil";
 
-	if (!(ObjectMemory::isBehavior(Oop(ote) && !ObjectMemory::isAMetaclass(reinterpret_cast<const OTE*>(ote)))))
+	if (!ote->m_oteClass->isMetaclass())
 		// Expected a Class Oop, but got something else
 		return stream << "**Non-class: " << reinterpret_cast<const OTE*>(ote) << "**";
 	else
@@ -158,7 +158,7 @@ ostream& operator<<(ostream& stream, const SymbolOTE* ote)
 
 	if (!ObjectMemory::isKindOf(Oop(ote), Pointers.ClassSymbol))
 		// Expected a Symbol Oop, but got something else
-		return stream << "**Non-symbol: " << reinterpret_cast<const OTE*>(ote) <<"**";
+		return stream << "**Non-symbol: " << reinterpret_cast<const OTE*>(ote) << "**";
 	else
 		// Dump without a # prefix
 		return stream << reinterpret_cast<const VariantCharOTE*>(ote);
@@ -170,11 +170,11 @@ ostream& operator<<(ostream& stream, const BehaviorOTE* ote)
 
 	if (!ObjectMemory::isBehavior(Oop(ote)))
 		// Expected a class Oop, but got something else
-		return stream << "**Non-behaviour: " << reinterpret_cast<const OTE*>(ote) <<"**";
+		return stream << "**Non-behaviour: " << reinterpret_cast<const OTE*>(ote) << "**";
 	else
 		return ote->isMetaclass() ?
-			stream << *static_cast<MetaClass*>(ote->m_location) :
-			stream << *static_cast<Class*>(ote->m_location);
+		stream << *static_cast<MetaClass*>(ote->m_location) :
+		stream << *static_cast<Class*>(ote->m_location);
 }
 
 ostream& operator<<(ostream& st, const UnknownOTE* ote)
@@ -191,7 +191,7 @@ ostream& operator<<(ostream& st, const LargeIntegerOTE* ote)
 	LargeInteger* li = ote->m_location;
 	st << "a LargeInteger(" << hex << setfill('0');
 	const int size = ote->getWordSize();
-	for (int i=size-1;i>=0;i--)
+	for (int i = size - 1; i >= 0; i--)
 		st << setw(8) << li->m_digits[i] << ' ';
 	return st << setfill(' ') << ')';
 }
@@ -209,7 +209,7 @@ ostream& operator<<(ostream& st, const ContextOTE* ote)
 	if (ote->isNil()) return st << "nil";
 	Context* ctx = ote->m_location;
 	return st << "a Context for: " << ctx->m_block
-			<< " frame: " << hex << ctx->m_frame ;
+		<< " frame: " << hex << ctx->m_frame;
 }
 
 ostream& operator<<(ostream& st, const VariableBindingOTE* ote)
@@ -244,8 +244,8 @@ ostream& operator<<(ostream& st, const ProcessOTE* ote)
 		sp = topFrame->stackPointer();
 	}
 
-	return st << " in " << topFrame->m_method << " sp=" << sp 
-		<< " ip=" << reinterpret_cast<OTE*>(topFrame->m_ip) 
+	return st << " in " << topFrame->m_method << " sp=" << sp
+		<< " ip=" << reinterpret_cast<OTE*>(topFrame->m_ip)
 		<< " list=" << proc->SuspendingList() << ")";
 }
 
@@ -305,7 +305,7 @@ ostream& operator<<(ostream& st, const ArrayOTE* ote)
 		{
 			int size = ote->pointersSize();
 			int end = min(40, size);
-			for (int i=0;i<end;i++)
+			for (int i = 0; i < end; i++)
 				st << reinterpret_cast<OTE*>(array->m_elements[i]) << " ";
 			if (end < size)
 				st << "...";
@@ -318,7 +318,7 @@ ostream& operator<<(ostream& stream, const OTE* ote)
 {
 	if (ObjectMemoryIsIntegerObject(ote))
 		return stream << dec << ObjectMemoryIntegerValueOf(ote);
-	
+
 	if (ote == NULL)
 		return stream << "NULL Oop";
 
@@ -328,13 +328,13 @@ ostream& operator<<(ostream& stream, const OTE* ote)
 	{
 		if (ote->isFree())
 			return stream << "***Freed object with Oop: " << PVOID(ote) <<
-					", class: " << ote->m_oteClass;
+			", class: " << ote->m_oteClass;
 	}
-	__except(EXCEPTION_EXECUTE_HANDLER)
+	__except (EXCEPTION_EXECUTE_HANDLER)
 	{
 		return stream << "***Bad Oop: " << PVOID(ote);
 	}
-	
+
 	// Handle specific object types
 	if (ote == Pointers.Nil)
 		stream << "nil";
@@ -348,18 +348,18 @@ ostream& operator<<(ostream& stream, const OTE* ote)
 		__try
 		{
 			const BehaviorOTE* classPointer = ote->m_oteClass;
-			
+
 			__try
 			{
 				if (classPointer->isFree())
 					return stream << "***Object (Oop " << PVOID(ote) << ") of the freed class Oop: " << PVOID(classPointer);
 			}
-			__except(EXCEPTION_EXECUTE_HANDLER)
+			__except (EXCEPTION_EXECUTE_HANDLER)
 			{
 				// Class OTE is bad
 				return stream << "***Object (Oop " << PVOID(ote) << ") with bad class Oop: " << PVOID(classPointer);
 			}
-			
+
 			if (ote->isBehavior())
 				stream << reinterpret_cast<const BehaviorOTE*>(ote);
 			else
@@ -388,20 +388,20 @@ ostream& operator<<(ostream& stream, const OTE* ote)
 					stream << reinterpret_cast<const FloatOTE*>(ote);
 				else if (classPointer == Pointers.ClassExternalHandle)
 					stream << reinterpret_cast<const HandleOTE*>(ote);
-	#ifdef _DEBUG
+#ifdef _DEBUG
 				else if (classPointer == Pointers.ClassArray)
 					stream << reinterpret_cast<const ArrayOTE*>(ote);
-	#endif
+#endif
 				else
 					stream << reinterpret_cast<const UnknownOTE*>(ote);
 			}
 		}
-		__except(EXCEPTION_EXECUTE_HANDLER)
+		__except (EXCEPTION_EXECUTE_HANDLER)
 		{
 			stream << "***Bad OTE or Object: " << LPVOID(ote) << '(' << ote->m_location << ')';
 		}
 	}
-	
+
 	return stream;
 }
 
@@ -418,13 +418,13 @@ void DumpStackEntry(Oop* sp, Process* pProc, ostream& stream)
 		Oop objectPointer = *sp;
 		OTE* ote = reinterpret_cast<OTE*>(objectPointer);
 		stream << ote;
-	#ifdef _DEBUG
+#ifdef _DEBUG
 		if (!ObjectMemoryIsIntegerObject(objectPointer))
 			stream << ", refs " << dec << int(ote->m_count);
-	#endif
+#endif
 		stream << endl;
 	}
-	__except(EXCEPTION_EXECUTE_HANDLER)
+	__except (EXCEPTION_EXECUTE_HANDLER)
 	{
 		stream << endl << '\t' << "***CORRUPT STACK ENTRY" << endl;
 	}
@@ -432,23 +432,23 @@ void DumpStackEntry(Oop* sp, Process* pProc, ostream& stream)
 
 // determine number of elements in an array (not bytes)
 #ifndef _countof
-	#define _countof(array) (sizeof(array)/sizeof(array[0]))
+#define _countof(array) (sizeof(array)/sizeof(array[0]))
 #endif
 
 /////////////////////////////////////////////////////////////////////////////
 // Formatted output
 
 void HexDump(tracestream out, LPCTSTR lpszLine, BYTE* pby,
-			 int nBytes, int nWidth)
-			 // do a simple hex-dump (8 per line) to a tracestream
-			 //  the "lpszLine" is a string to print at the start of each line
-			 //    (%lx should be used to expand the current address)
+	int nBytes, int nWidth)
+	// do a simple hex-dump (8 per line) to a tracestream
+	//  the "lpszLine" is a string to print at the start of each line
+	//    (%lx should be used to expand the current address)
 {
 	ASSERT(nBytes > 0);
 	ASSERT(nWidth > 0);
-	
+
 	int nRow = 0;
-	
+
 	char oldFill = out.fill('0');
 	out << hex;
 	out.setf(ios::uppercase);
@@ -460,9 +460,9 @@ void HexDump(tracestream out, LPCTSTR lpszLine, BYTE* pby,
 			wsprintf(szBuffer, lpszLine, pby);
 			out << szBuffer;
 		}
-		
+
 		out << ' ' << setw(2) << *pby++;
-		
+
 		if (++nRow >= nWidth)
 		{
 			out << endl;
@@ -471,7 +471,7 @@ void HexDump(tracestream out, LPCTSTR lpszLine, BYTE* pby,
 	}
 	if (nRow != 0)
 		out << endl;
-	
+
 	out.unsetf(ios::uppercase);
 	out.fill(oldFill);
 }
@@ -538,20 +538,20 @@ static void DumpStack(Oop* sp, Process* pProcess, ostream& logStream, unsigned n
 		else
 		{
 			// A short stack trace
-			unsigned i=0;
+			unsigned i = 0;
 			unsigned nSlots = sp - pProcess->m_stack;
 			if (nSlots > nDepth)
 			{
-				unsigned nHalfDepth = nDepth/2;
+				unsigned nHalfDepth = nDepth / 2;
 				while (sp >= pProcess->m_stack && i < nHalfDepth)
 				{
 					DumpStackEntry(sp, pProcess, logStream);
 					sp--;
 					i++;
 				}
-				logStream << "..." << endl 
-						<< "<" << dec << nSlots - nDepth << " slots omitted>" << endl 
-						<< "..." << endl;
+				logStream << "..." << endl
+					<< "<" << dec << nSlots - nDepth << " slots omitted>" << endl
+					<< "..." << endl;
 
 				sp = pProcess->m_stack + nHalfDepth;
 				while (sp >= pProcess->m_stack)
@@ -604,7 +604,7 @@ ostream& operator<<(ostream& stream, StackFrame *pFrame)
 		CompiledMethod* method = oteMethod->m_location;
 		int ip = ObjectMemoryIntegerValueOf(pFrame->m_ip);
 		if (ip != 0)
-			ip += isIntegerObject(method->m_byteCodes) ? 1 : -(int(ObjectByteSize)-1);
+			ip += isIntegerObject(method->m_byteCodes) ? 1 : -(int(ObjectByteSize) - 1);
 
 		stream << '{' << LPVOID(pFrame)	// otherwise would be recursive!
 			<< ": cf " << LPVOID(pFrame->m_caller)
@@ -625,7 +625,7 @@ ostream& operator<<(ostream& stream, StackFrame *pFrame)
 			oteContext = NULL;
 			ctx = NULL;
 		}
-	
+
 		unsigned argc;
 		unsigned stackTempCount;
 		if (ctx != NULL && ctx->isBlockContext())
@@ -649,8 +649,8 @@ ostream& operator<<(ostream& stream, StackFrame *pFrame)
 			argc = method->m_header.argumentCount;
 			stackTempCount = method->m_header.stackTempCount;
 		}
-		
-		Oop receiver = *(bp-1);
+
+		Oop receiver = *(bp - 1);
 		if (receiver == Oop(Pointers.Nil))
 		{
 			stream << method->m_methodClass;
@@ -663,25 +663,25 @@ ostream& operator<<(ostream& stream, StackFrame *pFrame)
 			if (method->m_methodClass != receiverClass)
 				stream << '(' << method->m_methodClass << ')';
 		}
-		stream << ">>" << method->m_selector 
+		stream << ">>" << method->m_selector
 			<< '}' << endl;
 
 		stream << "	receiver: " << reinterpret_cast<OTE*>(receiver) << endl;
-		unsigned i=0;
-		for (i=0;i<argc;i++)
-			stream << "	arg[" << dec << i << "]: " << reinterpret_cast<OTE*>(*(bp+i)) << endl;
-		for (i=0;i<stackTempCount;i++)
-			stream << "	stack temp[" << dec << i << "]: " << reinterpret_cast<OTE*>(*(bp+i+argc)) << endl;
+		unsigned i = 0;
+		for (i = 0; i < argc; i++)
+			stream << "	arg[" << dec << i << "]: " << reinterpret_cast<OTE*>(*(bp + i)) << endl;
+		for (i = 0; i < stackTempCount; i++)
+			stream << "	stack temp[" << dec << i << "]: " << reinterpret_cast<OTE*>(*(bp + i + argc)) << endl;
 
 		if (ctx != NULL)
 		{
 			const unsigned envTempCount = oteContext->pointersSize() - Context::FixedSize;
-			for (i=0;i<envTempCount;i++)
+			for (i = 0; i < envTempCount; i++)
 				stream << "	env temp[" << dec << i << "]: " << reinterpret_cast<OTE*>(ctx->m_tempFrame[i]) << endl;
 		}
 
 		stream << endl;
-			
+
 	}
 	return stream;
 }
@@ -697,32 +697,32 @@ void Interpreter::DumpContext(EXCEPTION_POINTERS *pExceptionInfo, ostream& logSt
 void Interpreter::DumpContext(ostream& logStream)
 {
 	logStream << "*----> VM Context <----*" << endl;
-	
+
 	__try
 	{
 		logStream << "Process: ";
 		DumpProcess(m_registers.m_oteActiveProcess, logStream);
 	}
-	__except(EXCEPTION_EXECUTE_HANDLER)
+	__except (EXCEPTION_EXECUTE_HANDLER)
 	{
 		logStream << endl << '\t' << "***CORRUPT ACTIVE PROCESS OR CONTEXT";
 	}
-	
+
 	__try
 	{
 		logStream << "Active Method: " << *m_registers.m_pMethod;
 	}
-	__except(EXCEPTION_EXECUTE_HANDLER)
+	__except (EXCEPTION_EXECUTE_HANDLER)
 	{
 		logStream << endl << '\t' << "***CORRUPT CURRENT METHOD OR CONTEXT";
 	}
-	
+
 	__try
 	{
 		logStream << endl << "IP: ";
 		DumpIP(m_registers.m_instructionPointer, m_registers.m_pMethod, logStream);
 	}
-	__except(EXCEPTION_EXECUTE_HANDLER)
+	__except (EXCEPTION_EXECUTE_HANDLER)
 	{
 		logStream << endl << '\t' << "***CORRUPT IP, METHOD, OR CONTEXT";
 	}
@@ -734,34 +734,34 @@ void Interpreter::DumpContext(ostream& logStream)
 		logStream << "BP: ";
 		DumpBP(m_registers.m_basePointer, m_registers.activeProcess(), logStream);
 	}
-	__except(EXCEPTION_EXECUTE_HANDLER)
+	__except (EXCEPTION_EXECUTE_HANDLER)
 	{
 		logStream << endl << '\t' << "***CORRUPT SP, PROCESS, OR CONTEXT" << endl;
 	}
-	
+
 	__try
 	{
 		logStream << "ActiveFrame: " << m_registers.m_pActiveFrame << endl;
 	}
-	__except(EXCEPTION_EXECUTE_HANDLER)
+	__except (EXCEPTION_EXECUTE_HANDLER)
 	{
 		logStream << endl << '\t' << "***CORRUPT ACTIVE FRAME OR CONTEXT" << endl;
 	}
 
 	__try
 	{
-		logStream << "New Method: " << Interpreter::m_registers.m_oopNewMethod<< endl;
+		logStream << "New Method: " << Interpreter::m_registers.m_oopNewMethod << endl;
 	}
-	__except(EXCEPTION_EXECUTE_HANDLER)
+	__except (EXCEPTION_EXECUTE_HANDLER)
 	{
 		logStream << endl << '\t' << "***CORRUPT NEW METHOD OR CONTEXT" << endl;
 	}
-	
+
 	__try
 	{
 		logStream << "Message Selector: " << Interpreter::m_oopMessageSelector << endl;
 	}
-	__except(EXCEPTION_EXECUTE_HANDLER)
+	__except (EXCEPTION_EXECUTE_HANDLER)
 	{
 		logStream << endl << '\t' << "***CORRUPT SELECTOR OR CONTEXT" << endl;
 	}
@@ -779,7 +779,7 @@ void Interpreter::DumpStack(ostream& logStream, unsigned nStackDepth)
 	{
 		::DumpStack(m_registers.m_stackPointer, m_registers.activeProcess(), logStream, nStackDepth);
 	}
-	__except(EXCEPTION_EXECUTE_HANDLER)
+	__except (EXCEPTION_EXECUTE_HANDLER)
 	{
 		logStream << endl << '\t' << "***CORRUPT STACK" << endl;
 	}
@@ -804,14 +804,13 @@ void Interpreter::StackTraceOn(ostream& dc, StackFrame* pFrame, unsigned depth)
 		returnFrame = pFrame->m_caller;
 		pFrame = StackFrame::FromFrameOop(returnFrame);
 		depth--;
-	}
-	while (depth > 0 && returnFrame != ZeroPointer 
+	} while (depth > 0 && returnFrame != ZeroPointer
 #if 0 //def _DEBUG
 		&& !isCallbackFrame(returnFrame));
 #else
-	);
+		);
 #endif
-	
+
 	dc << (depth == 0 ? "<...more...>" : "<Bottom of stack>") << endl;
 }
 
@@ -822,7 +821,7 @@ void Interpreter::WarningWithStackTraceBody(const char* warningCaption, StackFra
 	TRACESTREAM << endl << warningCaption << endl;
 	StackTraceOn(TRACESTREAM, pFrame);
 	TRACESTREAM << endl;
-//		decodeMethod((pFrame?pFrame:m_registers.m_pActiveFrame)->m_method, dc);
+	//		decodeMethod((pFrame?pFrame:m_registers.m_pActiveFrame)->m_method, dc);
 	TRACESTREAM << endl << flush;
 }
 
@@ -833,10 +832,10 @@ void Interpreter::WarningWithStackTrace(const char* warningCaption, StackFrame* 
 		WarningWithStackTraceBody(warningCaption, pFrame);
 	}
 	// This used for debugging in exception handlers, so don't permit recursive exception
-	__except(GetExceptionCode() == EXCEPTION_ACCESS_VIOLATION ? EXCEPTION_EXECUTE_HANDLER : EXCEPTION_CONTINUE_SEARCH)
+	__except (GetExceptionCode() == EXCEPTION_ACCESS_VIOLATION ? EXCEPTION_EXECUTE_HANDLER : EXCEPTION_CONTINUE_SEARCH)
 	{
 	}
-	
+
 }
 #endif
 
@@ -857,8 +856,8 @@ BOOL Interpreter::isCallbackFrame(Oop framePointer)
 		CompiledMethod* cm = pFrame->m_method->m_location;
 		SymbolOTE* selector = cm->m_selector;
 		// Yucky yuck!
-		bRet =	selector == reinterpret_cast<SymbolOTE*>(Pointers.Nil) ||
-			selector == Pointers.callbackPerformSymbol ||	
+		bRet = selector == reinterpret_cast<SymbolOTE*>(Pointers.Nil) ||
+			selector == Pointers.callbackPerformSymbol ||
 			selector == Pointers.callbackPerformWithSymbol ||
 			selector == Pointers.callbackPerformWithWithSymbol ||
 			selector == Pointers.callbackPerformWithWithWithSymbol ||
@@ -876,7 +875,7 @@ void Interpreter::decodeMethod(CompiledMethod* meth, ostream* pstream)
 
 	// Report method header
 	STMethodHeader hdr = meth->m_header;
-	stream << "Method "<< meth;
+	stream << "Method " << meth;
 	if (hdr.primitiveIndex > 7)
 		stream << ", primitive=" << dec << int(hdr.primitiveIndex);
 	if (hdr.argumentCount > 0)
@@ -891,15 +890,15 @@ void Interpreter::decodeMethod(CompiledMethod* meth, ostream* pstream)
 		stream << "; needs context";
 	}
 	stream << endl;
-	
-	BYTE* bytecodes=ObjectMemory::ByteAddressOfObjectContents(meth->m_byteCodes);
-	unsigned size=ObjectMemoryIsIntegerObject(meth->m_byteCodes) ?
+
+	BYTE* bytecodes = ObjectMemory::ByteAddressOfObjectContents(meth->m_byteCodes);
+	unsigned size = ObjectMemoryIsIntegerObject(meth->m_byteCodes) ?
 		sizeof(SMALLINTEGER) : reinterpret_cast<ByteArrayOTE*>(meth->m_byteCodes)->bytesSize();
-	
-	BYTE* b=bytecodes;
-	while (b<bytecodes+size) 
+
+	BYTE* b = bytecodes;
+	while (b < bytecodes + size)
 	{
-		int ip=b-bytecodes;
+		int ip = b - bytecodes;
 		decodeMethodAt(meth, ip, stream);
 		b += lengthOfByteCode(*b);
 	}
@@ -908,136 +907,136 @@ void Interpreter::decodeMethod(CompiledMethod* meth, ostream* pstream)
 
 void Interpreter::decodeMethodAt(CompiledMethod* meth, unsigned ip, ostream& stream)
 {
-	BYTE* bp=(ObjectMemory::ByteAddressOfObjectContents(meth->m_byteCodes))+ip;
-	Oop* literalFrame=&(meth->m_aLiterals[0]);
-	
+	BYTE* bp = (ObjectMemory::ByteAddressOfObjectContents(meth->m_byteCodes)) + ip;
+	Oop* literalFrame = &(meth->m_aLiterals[0]);
+
 	const int opcode = bp[0];
 	stream << dec << setw(5) << ip << ":	" << dec << opcode << '	';
-	
-	switch (opcode) 
+
+	switch (opcode)
 	{
 	case Break:
 		stream << "Debug Break";
 		break;
 
-	case ShortPushInstVar+0:
-	case ShortPushInstVar+1:
-	case ShortPushInstVar+2:
-	case ShortPushInstVar+3:
-	case ShortPushInstVar+4:
-	case ShortPushInstVar+5:
-	case ShortPushInstVar+6:
-	case ShortPushInstVar+7:
-	case ShortPushInstVar+8:
-	case ShortPushInstVar+9:
-	case ShortPushInstVar+10:
-	case ShortPushInstVar+11:
-	case ShortPushInstVar+12:
-	case ShortPushInstVar+13:
-	case ShortPushInstVar+14:
-	case ShortPushInstVar+15:
+	case ShortPushInstVar + 0:
+	case ShortPushInstVar + 1:
+	case ShortPushInstVar + 2:
+	case ShortPushInstVar + 3:
+	case ShortPushInstVar + 4:
+	case ShortPushInstVar + 5:
+	case ShortPushInstVar + 6:
+	case ShortPushInstVar + 7:
+	case ShortPushInstVar + 8:
+	case ShortPushInstVar + 9:
+	case ShortPushInstVar + 10:
+	case ShortPushInstVar + 11:
+	case ShortPushInstVar + 12:
+	case ShortPushInstVar + 13:
+	case ShortPushInstVar + 14:
+	case ShortPushInstVar + 15:
 		stream << "Short Push InstVar[" << dec << int(opcode - ShortPushInstVar) << ']';
 		break;
-		
-	case ShortPushTemp+0:
-	case ShortPushTemp+1:
-	case ShortPushTemp+2:
-	case ShortPushTemp+3:
-	case ShortPushTemp+4:
-	case ShortPushTemp+5:
-	case ShortPushTemp+6:
-	case ShortPushTemp+7:
+
+	case ShortPushTemp + 0:
+	case ShortPushTemp + 1:
+	case ShortPushTemp + 2:
+	case ShortPushTemp + 3:
+	case ShortPushTemp + 4:
+	case ShortPushTemp + 5:
+	case ShortPushTemp + 6:
+	case ShortPushTemp + 7:
 		stream << "Short Push Temp[" << dec << int(opcode - ShortPushTemp) << "]";
 		break;
-		
-	case ShortPushConst+0:
-	case ShortPushConst+1:
-	case ShortPushConst+2:
-	case ShortPushConst+3:
-	case ShortPushConst+4:
-	case ShortPushConst+5:
-	case ShortPushConst+6:
-	case ShortPushConst+7:
-	case ShortPushConst+8:
-	case ShortPushConst+9:
-	case ShortPushConst+10:
-	case ShortPushConst+11:
-	case ShortPushConst+12:
-	case ShortPushConst+13:
-	case ShortPushConst+14:
-	case ShortPushConst+15:
-		{
-			int literal = opcode - ShortPushConst;
-			stream << "Short Push Const[" << literal << "]: " << reinterpret_cast<OTE*>(literalFrame[literal]);
-		}
-		break;
-		
-	case ShortPushStatic+0:
-	case ShortPushStatic+1:
-	case ShortPushStatic+2:
-	case ShortPushStatic+3:
-	case ShortPushStatic+4:
-	case ShortPushStatic+5:
-	case ShortPushStatic+6:
-	case ShortPushStatic+7:
-	case ShortPushStatic+8:
-	case ShortPushStatic+9:
-	case ShortPushStatic+10:
-	case ShortPushStatic+11:
-		{
-			int literal = opcode - ShortPushStatic;
-			stream << "Short Push Static[" << literal << "]: " << reinterpret_cast<OTE*>(literalFrame[literal]);
-		}
-		break;
-		
+
+	case ShortPushConst + 0:
+	case ShortPushConst + 1:
+	case ShortPushConst + 2:
+	case ShortPushConst + 3:
+	case ShortPushConst + 4:
+	case ShortPushConst + 5:
+	case ShortPushConst + 6:
+	case ShortPushConst + 7:
+	case ShortPushConst + 8:
+	case ShortPushConst + 9:
+	case ShortPushConst + 10:
+	case ShortPushConst + 11:
+	case ShortPushConst + 12:
+	case ShortPushConst + 13:
+	case ShortPushConst + 14:
+	case ShortPushConst + 15:
+	{
+		int literal = opcode - ShortPushConst;
+		stream << "Short Push Const[" << literal << "]: " << reinterpret_cast<OTE*>(literalFrame[literal]);
+	}
+	break;
+
+	case ShortPushStatic + 0:
+	case ShortPushStatic + 1:
+	case ShortPushStatic + 2:
+	case ShortPushStatic + 3:
+	case ShortPushStatic + 4:
+	case ShortPushStatic + 5:
+	case ShortPushStatic + 6:
+	case ShortPushStatic + 7:
+	case ShortPushStatic + 8:
+	case ShortPushStatic + 9:
+	case ShortPushStatic + 10:
+	case ShortPushStatic + 11:
+	{
+		int literal = opcode - ShortPushStatic;
+		stream << "Short Push Static[" << literal << "]: " << reinterpret_cast<OTE*>(literalFrame[literal]);
+	}
+	break;
+
 	case ShortPushNil:
 		stream << "Short Push Nil";
 		break;
-		
+
 	case ShortPushTrue:
 		stream << "Short Push True";
 		break;
-		
+
 	case ShortPushFalse:
 		stream << "Short Push False";
 		break;
-		
+
 	case ShortPushSelf:
 		stream << "Short Push Self";
 		break;
-		
+
 	case ShortPushMinusOne:
 		stream << "Short Push -1";
 		break;
-		
+
 	case ShortPushZero:
 		stream << "Short Push 0";
 		break;
-		
+
 	case ShortPushOne:
 		stream << "Short Push 1";
 		break;
-		
+
 	case ShortPushTwo:
 		stream << "Short Push 2";
 		break;
 
-	case ShortPushSelfAndTemp+0:
-	case ShortPushSelfAndTemp+1:
-	case ShortPushSelfAndTemp+2:	
-	case ShortPushSelfAndTemp+3:
+	case ShortPushSelfAndTemp + 0:
+	case ShortPushSelfAndTemp + 1:
+	case ShortPushSelfAndTemp + 2:
+	case ShortPushSelfAndTemp + 3:
 		stream << "Push Self and Temp[" << dec << int(opcode - ShortPushSelfAndTemp) << ']';
 		break;
 
-	case ShortStoreTemp+0:
-	case ShortStoreTemp+1:
-	case ShortStoreTemp+2:
-	case ShortStoreTemp+3:
+	case ShortStoreTemp + 0:
+	case ShortStoreTemp + 1:
+	case ShortStoreTemp + 2:
+	case ShortStoreTemp + 3:
 		stream << "Short Store Temp[" << dec << int(opcode - ShortStoreTemp) << "]";
 		break;
 
-	case ShortPopPushTemp+0:
-	case ShortPopPushTemp+1:
+	case ShortPopPushTemp + 0:
+	case ShortPopPushTemp + 1:
 		stream << "Pop & Push Temp[" << dec << int(opcode - ShortPopPushTemp) << "]";
 		break;
 
@@ -1049,80 +1048,80 @@ void Interpreter::decodeMethodAt(CompiledMethod* meth, unsigned ip, ostream& str
 		stream << "Pop & Dup";
 		break;
 
-	case ShortPushContextTemp+0:
-	case ShortPushContextTemp+1:	
+	case ShortPushContextTemp + 0:
+	case ShortPushContextTemp + 1:
 		stream << "Push Outer[0] Temp[" << dec << int(opcode - ShortPushContextTemp) << "]";
 		break;
 
-	case ShortPushOuterTemp+0:
-	case ShortPushOuterTemp+1:
+	case ShortPushOuterTemp + 0:
+	case ShortPushOuterTemp + 1:
 		stream << "Push Outer[1] Temp[" << dec << int(opcode - ShortPushOuterTemp) << "]";
 		break;
 
-	case PopStoreContextTemp+0:
-	case PopStoreContextTemp+1:
+	case PopStoreContextTemp + 0:
+	case PopStoreContextTemp + 1:
 		stream << "Pop Store Outer[0] Temp[" << dec << int(opcode - PopStoreContextTemp) << "]";
 		break;
 
-	case ShortPopStoreOuterTemp+0:
-	case ShortPopStoreOuterTemp+1:
+	case ShortPopStoreOuterTemp + 0:
+	case ShortPopStoreOuterTemp + 1:
 		stream << "Pop Store Outer[1] Temp[" << dec << int(opcode - ShortPopStoreOuterTemp) << "]";
 		break;
 
-	case ShortPopStoreInstVar+0:
-	case ShortPopStoreInstVar+1:
-	case ShortPopStoreInstVar+2:
-	case ShortPopStoreInstVar+3:
-	case ShortPopStoreInstVar+4:
-	case ShortPopStoreInstVar+5:
-	case ShortPopStoreInstVar+6:
-	case ShortPopStoreInstVar+7:
+	case ShortPopStoreInstVar + 0:
+	case ShortPopStoreInstVar + 1:
+	case ShortPopStoreInstVar + 2:
+	case ShortPopStoreInstVar + 3:
+	case ShortPopStoreInstVar + 4:
+	case ShortPopStoreInstVar + 5:
+	case ShortPopStoreInstVar + 6:
+	case ShortPopStoreInstVar + 7:
 		stream << "Short Pop Store InstVar[" << dec << int(opcode - ShortPopStoreInstVar) << "]";
 		break;
-		
-	case  ShortPopStoreTemp+0:
-	case  ShortPopStoreTemp+1:
-	case  ShortPopStoreTemp+2:
-	case  ShortPopStoreTemp+3:
-	case  ShortPopStoreTemp+4:
-	case  ShortPopStoreTemp+5:
-	case  ShortPopStoreTemp+6:
-	case  ShortPopStoreTemp+7:
+
+	case  ShortPopStoreTemp + 0:
+	case  ShortPopStoreTemp + 1:
+	case  ShortPopStoreTemp + 2:
+	case  ShortPopStoreTemp + 3:
+	case  ShortPopStoreTemp + 4:
+	case  ShortPopStoreTemp + 5:
+	case  ShortPopStoreTemp + 6:
+	case  ShortPopStoreTemp + 7:
 		stream << "Short Pop Store Temp[" << dec << int(opcode - ShortPopStoreTemp) << "]";
 		break;
-		
+
 	case PopStackTop:
 		stream << "Pop Stack Top";
 		break;
-		
+
 	case DuplicateStackTop:
 		stream << "Duplicate Stack Top";
 		break;
-		
+
 	case PushActiveFrame:
 		stream << "Push Active Frame";
 		break;
-		
+
 	case IncrementStackTop:
 		stream << "Increment Stack Top";
 		break;
-		
+
 	case DecrementStackTop:
 		stream << "Decrement Stack Top";
 		break;
-		
+
 	case ReturnNil:
 		stream << "Return Nil";
 		break;
-		
+
 	case ReturnTrue:
 		stream << "Return True";
 		break;
-		
+
 	case ReturnFalse:
 		stream << "Return False";
 		break;
-		
+
 	case ReturnSelf:
 		stream << "Return Self";
 		break;
@@ -1134,7 +1133,7 @@ void Interpreter::decodeMethodAt(CompiledMethod* meth, unsigned ip, ostream& str
 	case ReturnMessageStackTop:
 		stream << "Return Message stack top";
 		break;
-		
+
 	case ReturnBlockStackTop:
 		stream << "Return Block stack top";
 		break;
@@ -1146,144 +1145,144 @@ void Interpreter::decodeMethodAt(CompiledMethod* meth, unsigned ip, ostream& str
 	case Nop:
 		stream << "Nop";
 		break;
-		
-	case  ShortJump+0:
-	case  ShortJump+1:
-	case  ShortJump+2:
-	case  ShortJump+3:
-	case  ShortJump+4:
-	case  ShortJump+5:
-	case  ShortJump+6:
-	case  ShortJump+7:
-		{
-			BYTE offset = bp[0] - ShortJump;
-			stream << "Short Jump to " << dec << int(offset + ip + 1 + 1) << " (offset " << dec << int(offset) << ")";
-		}
-		break;
-		
-	case  ShortJumpIfFalse+0:
-	case  ShortJumpIfFalse+1:
-	case  ShortJumpIfFalse+2:
-	case  ShortJumpIfFalse+3:
-	case  ShortJumpIfFalse+4:
-	case  ShortJumpIfFalse+5:
-	case  ShortJumpIfFalse+6:
-	case  ShortJumpIfFalse+7:
-		{
-			BYTE offset = bp[0] - ShortJumpIfFalse;
-			stream << "Short Jump to " << dec << int(offset + ip + 1 + 1) << " If False (offset " << dec << int(offset) << ")";
-		}
-		break;
-		
+
+	case  ShortJump + 0:
+	case  ShortJump + 1:
+	case  ShortJump + 2:
+	case  ShortJump + 3:
+	case  ShortJump + 4:
+	case  ShortJump + 5:
+	case  ShortJump + 6:
+	case  ShortJump + 7:
+	{
+		BYTE offset = bp[0] - ShortJump;
+		stream << "Short Jump to " << dec << int(offset + ip + 1 + 1) << " (offset " << dec << int(offset) << ")";
+	}
+	break;
+
+	case  ShortJumpIfFalse + 0:
+	case  ShortJumpIfFalse + 1:
+	case  ShortJumpIfFalse + 2:
+	case  ShortJumpIfFalse + 3:
+	case  ShortJumpIfFalse + 4:
+	case  ShortJumpIfFalse + 5:
+	case  ShortJumpIfFalse + 6:
+	case  ShortJumpIfFalse + 7:
+	{
+		BYTE offset = bp[0] - ShortJumpIfFalse;
+		stream << "Short Jump to " << dec << int(offset + ip + 1 + 1) << " If False (offset " << dec << int(offset) << ")";
+	}
+	break;
+
 	case SendArithmeticAdd:
 	case SendArithmeticSub:
-	case ShortSpecialSend+2:
-	case ShortSpecialSend+3:
-	case ShortSpecialSend+4:
-	case ShortSpecialSend+5:
-	case ShortSpecialSend+6:
-	case ShortSpecialSend+7:
-	case ShortSpecialSend+8:
-	case ShortSpecialSend+9:
-	case ShortSpecialSend+10:
-	case ShortSpecialSend+11:
-	case ShortSpecialSend+12:
-	case ShortSpecialSend+13:
-	case ShortSpecialSend+14:
-	case ShortSpecialSend+15:
-	case ShortSpecialSend+16:
-	case ShortSpecialSend+17:
-	case ShortSpecialSend+18:
-	case ShortSpecialSend+19:
-	case ShortSpecialSend+20:
-	case ShortSpecialSend+21:
-	case ShortSpecialSend+22:
-	case ShortSpecialSend+23:
-	case ShortSpecialSend+24:
-	case ShortSpecialSend+25:
-	case ShortSpecialSend+26:
-	case ShortSpecialSend+27:
-	case ShortSpecialSend+28:
-	case ShortSpecialSend+29:
-	case ShortSpecialSend+30:
-	case ShortSpecialSend+31:
-		{
-			SymbolOTE*const* pSpecialSelectors = Pointers.specialSelectors;
-			const SymbolOTE* stringPointer = pSpecialSelectors[opcode - ShortSpecialSend];
-			_ASSERTE(ObjectMemory::isKindOf(stringPointer, Pointers.ClassString));
-			stream << "Short Special Send " << stringPointer;
-		}
-		break;
-		
-		
-	case ShortSendWithNoArgs+0:
-	case ShortSendWithNoArgs+1:
-	case ShortSendWithNoArgs+2:
-	case ShortSendWithNoArgs+3:
-	case ShortSendWithNoArgs+4:
-	case ShortSendWithNoArgs+5:
-	case ShortSendWithNoArgs+6:
-	case ShortSendWithNoArgs+7:
-	case ShortSendWithNoArgs+8:
-	case ShortSendWithNoArgs+9:
-	case ShortSendWithNoArgs+10:
-	case ShortSendWithNoArgs+11:
-	case ShortSendWithNoArgs+12:
-		{
-			int literal = opcode - ShortSendWithNoArgs;
-			stream << "Short Send " << reinterpret_cast<SymbolOTE*>(literalFrame[literal]) << 
-				" with no args (literal " << dec << literal << ')';
-		}
-		break;
-		
-	case ShortSendSelfWithNoArgs+0:
-	case ShortSendSelfWithNoArgs+1:	
-	case ShortSendSelfWithNoArgs+2:	
-	case ShortSendSelfWithNoArgs+3:
-	case ShortSendSelfWithNoArgs+4:
-		{
-			int literal = opcode - ShortSendSelfWithNoArgs;
-			stream << "Short Send Self " << reinterpret_cast<OTE*>(literalFrame[literal]) << 
-				" with no args (literal " << dec << literal << ')';
-		}
-		break;
+	case ShortSpecialSend + 2:
+	case ShortSpecialSend + 3:
+	case ShortSpecialSend + 4:
+	case ShortSpecialSend + 5:
+	case ShortSpecialSend + 6:
+	case ShortSpecialSend + 7:
+	case ShortSpecialSend + 8:
+	case ShortSpecialSend + 9:
+	case ShortSpecialSend + 10:
+	case ShortSpecialSend + 11:
+	case ShortSpecialSend + 12:
+	case ShortSpecialSend + 13:
+	case ShortSpecialSend + 14:
+	case ShortSpecialSend + 15:
+	case ShortSpecialSend + 16:
+	case ShortSpecialSend + 17:
+	case ShortSpecialSend + 18:
+	case ShortSpecialSend + 19:
+	case ShortSpecialSend + 20:
+	case ShortSpecialSend + 21:
+	case ShortSpecialSend + 22:
+	case ShortSpecialSend + 23:
+	case ShortSpecialSend + 24:
+	case ShortSpecialSend + 25:
+	case ShortSpecialSend + 26:
+	case ShortSpecialSend + 27:
+	case ShortSpecialSend + 28:
+	case ShortSpecialSend + 29:
+	case ShortSpecialSend + 30:
+	case ShortSpecialSend + 31:
+	{
+		SymbolOTE*const* pSpecialSelectors = Pointers.specialSelectors;
+		const SymbolOTE* stringPointer = pSpecialSelectors[opcode - ShortSpecialSend];
+		_ASSERTE(ObjectMemory::isKindOf(stringPointer, Pointers.ClassString));
+		stream << "Short Special Send " << stringPointer;
+	}
+	break;
 
-	case ShortSendWith1Arg+0:
-	case ShortSendWith1Arg+1:
-	case ShortSendWith1Arg+2:
-	case ShortSendWith1Arg+3:
-	case ShortSendWith1Arg+4:
-	case ShortSendWith1Arg+5:
-	case ShortSendWith1Arg+6:
-	case ShortSendWith1Arg+7:
-	case ShortSendWith1Arg+8:
-	case ShortSendWith1Arg+9:
-	case ShortSendWith1Arg+10:
-	case ShortSendWith1Arg+11:
-	case ShortSendWith1Arg+12:
-	case ShortSendWith1Arg+13:
-		{
-			int literal = opcode - ShortSendWith1Arg;
-			stream << "Short Send " << reinterpret_cast<OTE*>(literalFrame[literal]) <<
-				" with 1 arg (literal " << dec << literal << ')';
-		}
-		break;
-		
-	case ShortSendWith2Args+0:
-	case ShortSendWith2Args+1:
-	case ShortSendWith2Args+2:
-	case ShortSendWith2Args+3:
-	case ShortSendWith2Args+4:
-	case ShortSendWith2Args+5:
-	case ShortSendWith2Args+6:
-	case ShortSendWith2Args+7:
-		{
-			int literal = opcode - ShortSendWith2Args;
-			stream << "Short Send " << reinterpret_cast<OTE*>(literalFrame[literal]) <<
-				" with 2 args (literal " << dec << literal << ')';
-		}
-		break;
-		
+
+	case ShortSendWithNoArgs + 0:
+	case ShortSendWithNoArgs + 1:
+	case ShortSendWithNoArgs + 2:
+	case ShortSendWithNoArgs + 3:
+	case ShortSendWithNoArgs + 4:
+	case ShortSendWithNoArgs + 5:
+	case ShortSendWithNoArgs + 6:
+	case ShortSendWithNoArgs + 7:
+	case ShortSendWithNoArgs + 8:
+	case ShortSendWithNoArgs + 9:
+	case ShortSendWithNoArgs + 10:
+	case ShortSendWithNoArgs + 11:
+	case ShortSendWithNoArgs + 12:
+	{
+		int literal = opcode - ShortSendWithNoArgs;
+		stream << "Short Send " << reinterpret_cast<SymbolOTE*>(literalFrame[literal]) <<
+			" with no args (literal " << dec << literal << ')';
+	}
+	break;
+
+	case ShortSendSelfWithNoArgs + 0:
+	case ShortSendSelfWithNoArgs + 1:
+	case ShortSendSelfWithNoArgs + 2:
+	case ShortSendSelfWithNoArgs + 3:
+	case ShortSendSelfWithNoArgs + 4:
+	{
+		int literal = opcode - ShortSendSelfWithNoArgs;
+		stream << "Short Send Self " << reinterpret_cast<OTE*>(literalFrame[literal]) <<
+			" with no args (literal " << dec << literal << ')';
+	}
+	break;
+
+	case ShortSendWith1Arg + 0:
+	case ShortSendWith1Arg + 1:
+	case ShortSendWith1Arg + 2:
+	case ShortSendWith1Arg + 3:
+	case ShortSendWith1Arg + 4:
+	case ShortSendWith1Arg + 5:
+	case ShortSendWith1Arg + 6:
+	case ShortSendWith1Arg + 7:
+	case ShortSendWith1Arg + 8:
+	case ShortSendWith1Arg + 9:
+	case ShortSendWith1Arg + 10:
+	case ShortSendWith1Arg + 11:
+	case ShortSendWith1Arg + 12:
+	case ShortSendWith1Arg + 13:
+	{
+		int literal = opcode - ShortSendWith1Arg;
+		stream << "Short Send " << reinterpret_cast<OTE*>(literalFrame[literal]) <<
+			" with 1 arg (literal " << dec << literal << ')';
+	}
+	break;
+
+	case ShortSendWith2Args + 0:
+	case ShortSendWith2Args + 1:
+	case ShortSendWith2Args + 2:
+	case ShortSendWith2Args + 3:
+	case ShortSendWith2Args + 4:
+	case ShortSendWith2Args + 5:
+	case ShortSendWith2Args + 6:
+	case ShortSendWith2Args + 7:
+	{
+		int literal = opcode - ShortSendWith2Args;
+		stream << "Short Send " << reinterpret_cast<OTE*>(literalFrame[literal]) <<
+			" with 2 args (literal " << dec << literal << ')';
+	}
+	break;
+
 	case SpecialSendIsZero:
 		stream << "Special Send Is Zero";
 		break;
@@ -1291,11 +1290,11 @@ void Interpreter::decodeMethodAt(CompiledMethod* meth, unsigned ip, ostream& str
 	case PushInstVar:
 		stream << "Push Instance Variable[" << dec << int(bp[1]) << ']';
 		break;
-		
+
 	case PushTemp:
 		stream << "Push Temp[" << dec << int(bp[1]) << ']';
 		break;
-		
+
 	case PushOuterTemp:
 		stream << "Push Outer[" << dec << int(bp[1] >> 5) <<
 			"] Temp[" << dec << int(bp[1] & 0x1F) << ']';
@@ -1305,20 +1304,20 @@ void Interpreter::decodeMethodAt(CompiledMethod* meth, unsigned ip, ostream& str
 		stream << "Push Const[" << dec << int(bp[1]) << "]: "
 			<< reinterpret_cast<OTE*>(literalFrame[bp[1]]);
 		break;
-		
+
 	case PushStatic:
 		stream << "Push Static[" << dec << int(bp[1]) << "]: "
 			<< reinterpret_cast<OTE*>(literalFrame[bp[1]]);
 		break;
-		
+
 	case StoreInstVar:
 		stream << "Store Instance Variable[" << dec << int(bp[1]) << ']';
 		break;
-		
+
 	case StoreTemp:
 		stream << "Store Temp[" << dec << int(bp[1]) << ']';
 		break;
-	
+
 	case StoreOuterTemp:
 		stream << "Store Outer[" << dec << int(bp[1] >> 5) <<
 			"] Temp[" << dec << int(bp[1] & 0x1F) << ']';
@@ -1327,11 +1326,11 @@ void Interpreter::decodeMethodAt(CompiledMethod* meth, unsigned ip, ostream& str
 	case StoreStatic:
 		stream << "Store Static[" << dec << int(bp[1]) << "]: " << reinterpret_cast<OTE*>(literalFrame[bp[1]]);
 		break;
-		
+
 	case PopStoreInstVar:
 		stream << "Pop And Store Instance Variable[" << dec << int(bp[1]) << ']';
 		break;
-		
+
 	case PopStoreTemp:
 		stream << "Pop And Store Temp[" << dec << int(bp[1]) << ']';
 		break;
@@ -1344,155 +1343,155 @@ void Interpreter::decodeMethodAt(CompiledMethod* meth, unsigned ip, ostream& str
 	case PopStoreStatic:
 		stream << "Pop and Store Static[" << dec << int(bp[1]) << "]: " << reinterpret_cast<OTE*>(literalFrame[bp[1]]);
 		break;
-		
+
 	case PushImmediate:
 		stream << "Push Immediate " << dec << int(SBYTE(bp[1]));
 		break;
-		
+
 	case PushChar:
-		stream << "Push Char $" << char('\0'+bp[1]);
+		stream << "Push Char $" << char('\0' + bp[1]);
 		break;
-		
+
 	case Send:
 		stream << "Send " << reinterpret_cast<OTE*>(literalFrame[bp[1] & SendXMaxLiteral]) <<
-			" (literal " << dec << int(bp[1] & SendXMaxLiteral) << "), with " << 
+			" (literal " << dec << int(bp[1] & SendXMaxLiteral) << "), with " <<
 			int(bp[1] >> SendXLiteralBits) << " args";
 		break;
-		
+
 	case Supersend:
 		stream << "Supersend " << reinterpret_cast<OTE*>(literalFrame[bp[1] & SendXMaxLiteral]) <<
-			" (literal " << dec << int(bp[1] & SendXMaxLiteral) << "), with " << 
+			" (literal " << dec << int(bp[1] & SendXMaxLiteral) << "), with " <<
 			int(bp[1] >> SendXLiteralBits) << " args";
 		break;
-		
+
 	case NearJump:
-		{
-			int extension = int(SBYTE(bp[1]));
-			stream << "Near Jump to " << dec << (extension + 2 + ip);
-		}
-		break;
-		
+	{
+		int extension = int(SBYTE(bp[1]));
+		stream << "Near Jump to " << dec << (extension + 2 + ip);
+	}
+	break;
+
 	case NearJumpIfTrue:
-		{
-			int extension = int(bp[1]);
-			stream << "Near Jump If True to " << dec << (extension + 2 + ip);
-		}
-		break;
-		
+	{
+		int extension = int(bp[1]);
+		stream << "Near Jump If True to " << dec << (extension + 2 + ip);
+	}
+	break;
+
 	case NearJumpIfFalse:
-		{
-			int extension = int(bp[1]);
-			stream << "Near Jump If False to " << dec << (extension + 2 + ip);
-		}
-		break;
+	{
+		int extension = int(bp[1]);
+		stream << "Near Jump If False to " << dec << (extension + 2 + ip);
+	}
+	break;
 
 	case NearJumpIfNil:
-		{
-			int extension = int(bp[1]);
-			stream << "Near Jump If Nil to " << dec << (extension + 2 + ip);
-		}
-		break;
+	{
+		int extension = int(bp[1]);
+		stream << "Near Jump If Nil to " << dec << (extension + 2 + ip);
+	}
+	break;
 
 	case NearJumpIfNotNil:
-		{
-			int extension = int(bp[1]);
-			stream << "Near Jump If Not Nil to " << dec << (extension + 2 + ip);
-		}
-		break;
+	{
+		int extension = int(bp[1]);
+		stream << "Near Jump If Not Nil to " << dec << (extension + 2 + ip);
+	}
+	break;
 
 	case SendTempWithNoArgs:
-		{
-			int extension = int(bp[1]);
-			int literal = extension & SendXMaxLiteral;
-			int temp = extension >> SendXLiteralBits;
-			stream << "Send Temp [" << temp << "] " << reinterpret_cast<OTE*>(literalFrame[literal]) << 
-				" with no args (literal " << dec << literal << ')';
-		}
-		break;
+	{
+		int extension = int(bp[1]);
+		int literal = extension & SendXMaxLiteral;
+		int temp = extension >> SendXLiteralBits;
+		stream << "Send Temp [" << temp << "] " << reinterpret_cast<OTE*>(literalFrame[literal]) <<
+			" with no args (literal " << dec << literal << ')';
+	}
+	break;
 
 	case PushSelfAndTemp:
-		{
-			int extension = int(bp[1]);
-			stream << "Push Self; Push Temp[" << dec << extension << ']';
-		}
-		break;
+	{
+		int extension = int(bp[1]);
+		stream << "Push Self; Push Temp[" << dec << extension << ']';
+	}
+	break;
 
 	case SendSelfWithNoArgs:
-		{
-			int literal = int(bp[1]);
-			stream << "Send Self " << reinterpret_cast<OTE*>(literalFrame[literal]) << 
-				" with no args (literal " << dec << literal << ')';
-		}
-		break;
+	{
+		int literal = int(bp[1]);
+		stream << "Send Self " << reinterpret_cast<OTE*>(literalFrame[literal]) <<
+			" with no args (literal " << dec << literal << ')';
+	}
+	break;
 
 	case PushTempPair:
-		{
-			int n = bp[1] >> 4;
-			int m = bp[1] & 0xF;
-			stream << dec << "Push Temp[" << n << "] & Temp [" << m << "]";
-		}
-		break;
+	{
+		int n = bp[1] >> 4;
+		int m = bp[1] & 0xF;
+		stream << dec << "Push Temp[" << n << "] & Temp [" << m << "]";
+	}
+	break;
 
 	// Three bytes from here on ...
 	case LongPushConst:
-		{
-			WORD index = *reinterpret_cast<WORD*>(bp+1);
-			stream << " Long Push Const[" << dec << index << "]: " << reinterpret_cast<OTE*>(literalFrame[index]);
-		}
-		break;
-		
+	{
+		WORD index = *reinterpret_cast<WORD*>(bp + 1);
+		stream << " Long Push Const[" << dec << index << "]: " << reinterpret_cast<OTE*>(literalFrame[index]);
+	}
+	break;
+
 	case LongPushStatic:
-		{
-			WORD index = *reinterpret_cast<WORD*>(bp+1);
-			stream << " Long Push Static[" << dec << index << "]: " << reinterpret_cast<OTE*>(literalFrame[index]);
-		}
-		break;
-		
+	{
+		WORD index = *reinterpret_cast<WORD*>(bp + 1);
+		stream << " Long Push Static[" << dec << index << "]: " << reinterpret_cast<OTE*>(literalFrame[index]);
+	}
+	break;
+
 	case LongStoreStatic:
-		{
-			WORD index = *reinterpret_cast<WORD*>(bp+1);
-			stream << "Long Store Static[" << dec << index << "]: " << reinterpret_cast<OTE*>(literalFrame[index]);
-		}
-		break;
-		
+	{
+		WORD index = *reinterpret_cast<WORD*>(bp + 1);
+		stream << "Long Store Static[" << dec << index << "]: " << reinterpret_cast<OTE*>(literalFrame[index]);
+	}
+	break;
+
 	case LongPushImmediate:
-		{
-			int extension = static_cast<int>(*reinterpret_cast<SWORD*>(&bp[1]));
-			stream << "Long Push Immediate " << dec << extension;
-		}
-		break;
-		
+	{
+		int extension = static_cast<int>(*reinterpret_cast<SWORD*>(&bp[1]));
+		stream << "Long Push Immediate " << dec << extension;
+	}
+	break;
+
 	case LongSend:
 		stream << "Long Send[" << dec << int(bp[2]) << "], " << dec << int(bp[1]) << " args = "
 			<< reinterpret_cast<OTE*>(literalFrame[bp[2]]);
 		break;
-		
+
 	case LongSupersend:
 		stream << "Long Supersend[" << dec << int(bp[2]) << "], " << dec << int(bp[1]) << " args = "
 			<< reinterpret_cast<OTE*>(literalFrame[bp[2]]);
 		break;
-		
-		
+
+
 	case LongJump:
-		{
-			int extension = static_cast<int>(*reinterpret_cast<SWORD*>(&bp[1]));
-			stream << "Long Jump to " << dec << ip + 3 + extension;
-		}
-		break;
-		
+	{
+		int extension = static_cast<int>(*reinterpret_cast<SWORD*>(&bp[1]));
+		stream << "Long Jump to " << dec << ip + 3 + extension;
+	}
+	break;
+
 	case LongJumpIfTrue:
-		{
-			int extension = static_cast<int>(*reinterpret_cast<SWORD*>(&bp[1]));
-			stream << "Long Jump If True to " << dec << ip + 3 + extension;
-		}
-		break;
-		
+	{
+		int extension = static_cast<int>(*reinterpret_cast<SWORD*>(&bp[1]));
+		stream << "Long Jump If True to " << dec << ip + 3 + extension;
+	}
+	break;
+
 	case LongJumpIfFalse:
-		{
-			int extension = static_cast<int>(*reinterpret_cast<SWORD*>(&bp[1]));
-			stream << "Long Jump If False to " << dec << ip + 3 + extension;
-		}
-		break;
+	{
+		int extension = static_cast<int>(*reinterpret_cast<SWORD*>(&bp[1]));
+		stream << "Long Jump If False to " << dec << ip + 3 + extension;
+	}
+	break;
 
 	case LongPushOuterTemp:
 		stream << "Long Push Outer[" << dec << int(bp[1]) <<
@@ -1521,28 +1520,35 @@ void Interpreter::decodeMethodAt(CompiledMethod* meth, unsigned ip, ostream& str
 		break;
 
 	case BlockCopy:
-		{
-			int nArgs = bp[1];
-			stream << "Block Copy, ";
-			if (nArgs > 0)
-				stream << nArgs << " args, ";
-			int nStackTemps = bp[2];
-			if (nStackTemps > 0)
-				stream << nStackTemps << " stack temps, ";
-			int nEnvTemps = bp[3] >> 1;
-			int nCopied = bp[4] >> 1;
-			if (nEnvTemps > 0)
-				stream << nEnvTemps << " env temps, ";
-			if (nCopied > 0)
-				stream << nCopied << " copied values, ";
-			if (bp[4] & 1)
-				stream << "needs self, ";
-			if (bp[3] & 1)
-				stream << "needs outer, ";
-			stream << "length: " << *reinterpret_cast<WORD*>(bp+5);
-		}
-		break;
-		
+	{
+		int nArgs = bp[1];
+		stream << "Block Copy, ";
+		if (nArgs > 0)
+			stream << nArgs << " args, ";
+		int nStackTemps = bp[2];
+		if (nStackTemps > 0)
+			stream << nStackTemps << " stack temps, ";
+		int nEnvTemps = bp[3] >> 1;
+		int nCopied = bp[4] >> 1;
+		if (nEnvTemps > 0)
+			stream << nEnvTemps << " env temps, ";
+		if (nCopied > 0)
+			stream << nCopied << " copied values, ";
+		if (bp[4] & 1)
+			stream << "needs self, ";
+		if (bp[3] & 1)
+			stream << "needs outer, ";
+		stream << "length: " << *reinterpret_cast<WORD*>(bp + 5);
+	}
+	break;
+
+	case ExLongPushImmediate:
+	{
+		int extension = static_cast<int>(*reinterpret_cast<SDWORD*>(&bp[1]));
+		stream << "Ex Long Push Immediate " << dec << extension;
+	}
+	break;
+
 	default:
 		stream << "UNHANDLED BYTE CODE " << opcode << "!!!";
 		break;
@@ -1575,35 +1581,35 @@ void DumpObject(const POTE pote)
 // interpreter
 void Interpreter::checkStack(Oop* sp)
 {
-/*		for (unsigned i=1;i<=50;i++)
-{
-Oop objectPointer = sp[i];
-if (!ObjectMemoryIsIntegerObject(objectPointer) &&
-((reinterpret_cast<OTE*>(objectPointer)->getCount() < MAXCOUNT)
-{
-TRACESTREAM << "WARNING: sp+" << i << " contains " << objectPointer << endl;
-}
-}
-	*/		if (abs(executionTrace) > 3)
+	/*		for (unsigned i=1;i<=50;i++)
 	{
-		ProcessOTE* oteActive = m_registers.m_oteActiveProcess;
-		MWORD size = oteActive->getSize();
-		m_registers.ResizeProcess();
-		ObjectMemory::checkReferences();
-		oteActive->setSize(size);
+	Oop objectPointer = sp[i];
+	if (!ObjectMemoryIsIntegerObject(objectPointer) &&
+	((reinterpret_cast<OTE*>(objectPointer)->getCount() < MAXCOUNT)
+	{
+	TRACESTREAM << "WARNING: sp+" << i << " contains " << objectPointer << endl;
 	}
+	}
+		*/		if (abs(executionTrace) > 3)
+		{
+			ProcessOTE* oteActive = m_registers.m_oteActiveProcess;
+			MWORD size = oteActive->getSize();
+			m_registers.ResizeProcess();
+			ObjectMemory::checkReferences();
+			oteActive->setSize(size);
+		}
 }
 
 void __fastcall Interpreter::debugReturnToMethod(Oop* sp)
 {
-	#if 0
+#if 0
 	{
 		tracelock lock(TRACESTREAM);
 		TRACESTREAM << "* Returned to Method: " << *m_registers.m_pMethod << endl;
 		CHECKREFERENCES
 	}
-	#endif
-}
+#endif
+		}
 
 void __fastcall Interpreter::debugMethodActivated(Oop* sp)
 {
@@ -1621,23 +1627,23 @@ void __fastcall Interpreter::debugExecTrace(BYTE* ip, Oop* sp)
 {
 	//for (unsigned i=0;i<contextDepth;i++)
 	//	TRACESTREAM << ".";
-	
+
 	// To avoid covering bugs, we make sure we don't update the
 	// context for longer than the duration of the trace
 	BYTE* oldIP = m_registers.m_instructionPointer;
 	Oop* oldSP = m_registers.m_stackPointer;
 	m_registers.m_stackPointer = sp;
 	m_registers.m_instructionPointer = ip;
-	
+
 	if (abs(executionTrace) > 3)
 		checkStack(sp);
-	
+
 	if (executionTrace > 0)
 	{
 		tracelock lock(TRACESTREAM);
 		DumpStackEntry(sp, m_registers.m_pActiveProcess, TRACESTREAM);
 		TODO("Get rid of this bodge by changing the way decode works")
-		CompiledMethod* method = m_registers.m_pMethod;
+			CompiledMethod* method = m_registers.m_pMethod;
 		int ipIndex = int(ip - ObjectMemory::ByteAddressOfObjectContents(method->m_byteCodes));
 		HARDASSERT(ipIndex >= 0 && ipIndex < 1024);
 		//for (i=0;i<contextDepth;i++)
@@ -1650,7 +1656,7 @@ void __fastcall Interpreter::debugExecTrace(BYTE* ip, Oop* sp)
 
 		TRACESTREAM.flush();
 	}
-	
+
 	HARDASSERT(!m_registers.m_pActiveProcess->IsWaiting());
 	HARDASSERT(m_registers.m_pActiveProcess->Next()->isNil());
 
@@ -1691,7 +1697,7 @@ void DumpBytecodeCounts(bool bClear)
 {
 
 	TRACESTREAM << endl << "Bytecode invocation counts" << endl << "-----------------------------" << endl;
-	for (int i=0;i<256;i++)
+	for (int i = 0; i < 256; i++)
 	{
 		TRACESTREAM << dec << i << ": " << byteCodeCounters[i] << endl;
 		if (bClear) byteCodeCounters[i] = 0;
@@ -1699,12 +1705,12 @@ void DumpBytecodeCounts(bool bClear)
 	TRACESTREAM << "-----------------------------" << endl << endl;
 
 	TRACESTREAM << endl << "Bytecode pair counts" << endl << "-----------------------------" << endl;
-	for (int i=0;i<256;i++)
+	for (int i = 0; i < 256; i++)
 	{
-		for (int j=0;j<256;j++)
+		for (int j = 0; j < 256; j++)
 		{
-			TRACESTREAM << byteCodePairs[i*256+j] << ' ';
-			if (bClear) byteCodePairs[i*256+j] = 0;
+			TRACESTREAM << byteCodePairs[i * 256 + j] << ' ';
+			if (bClear) byteCodePairs[i * 256 + j] = 0;
 		}
 		TRACESTREAM << endl;
 	}
@@ -1717,7 +1723,7 @@ extern "C" unsigned primitiveCounters[];
 void DumpPrimitiveCounts(bool bClear)
 {
 	TRACESTREAM << endl << "Primitive invocation counts" << endl << "-----------------------------" << endl;
-	for (int i=0;i<=PRIMITIVE_MAX;i++)
+	for (int i = 0; i <= PRIMITIVE_MAX; i++)
 	{
 		TRACESTREAM << dec << i << ": " << primitiveCounters[i] << endl;
 		if (bClear) primitiveCounters[i] = 0;

--- a/primasm.asm
+++ b/primasm.asm
@@ -348,6 +348,7 @@ extern PRIMSTRINGSEARCH:near32
 PRIMSTRINGNEXTINDEX EQU ?primitiveStringNextIndexOfFromTo@Interpreter@@CIHXZ
 extern PRIMSTRINGNEXTINDEX:near32
 
+; Note this function returns 'bool', i.e. single byte in al; doesn't necessarily set whole of eax
 DISABLEINTERRUPTS EQU ?disableInterrupts@Interpreter@@SI_N_N@Z
 extern DISABLEINTERRUPTS:near32
 
@@ -2756,7 +2757,7 @@ BEGINPRIMITIVE primitiveEnableInterrupts
 	call	DISABLEINTERRUPTS
 
 	mov		ecx, [oteTrue]
-	cmp		eax, 0								; Interrupts not previously disabled?
+	test	al, al								; Interrupts not previously disabled?
 	je		@F									; Yes, answer true
 	add		ecx, OTENTRYSIZE					; No, answer false
 @@:


### PR DESCRIPTION
1. primitiveEnableInterrupts is supposed to return whether interrupts were enabled when it was called, but always returns false. This leads to interrupts being left disabled by code such as that in InputState>>windowAt:put:
1. primitiveLongDoubleAt: is missing an fwait, and so detection of any FP exceptions are delayed until the next fwait in a subsequent FP operation.
1. primitiveIndirectDwordAtPut pops the stack before attempting the actual write to memory, so if the write fails on an access violation, then the stack will be incorrect when the method is activated.
