### PR TITLE
Replace x86 assembler FP primitives with C++ implementations

### DIFF
--- a/ConsoleStub/wincons.cpp
+++ b/ConsoleStub/wincons.cpp
@@ -27,9 +27,9 @@ int __stdcall DolphinMessage(UINT flags, const char* msg)
 	return 0;
 }
 
-BOOL __fastcall Interpreter::primitiveHookWindowCreate()
+Oop* __fastcall Interpreter::primitiveHookWindowCreate()
 {
-	return FALSE;
+	return NULL;
 }
 
 #pragma code_seg(INIT_SEG)

--- a/GC.cpp
+++ b/GC.cpp
@@ -264,7 +264,7 @@ void ObjectMemory::reclaimInaccessibleObjects(DWORD gcFlags)
 #ifdef _DEBUG
 					{
 						tracelock lock(TRACESTREAM);
-						TRACESTREAM << "Weakling: " << ote << " (" << UINT(ote) << " lost " << losses << " elements" << endl;
+						TRACESTREAM << "Weakling: " << ote << " (" << hex << UINT(ote) << ") lost " << losses << " elements" << endl;
 					}
 #endif
 					// We must also ensure that it and its referenced objects are marked since we're

--- a/GC.cpp
+++ b/GC.cpp
@@ -630,14 +630,6 @@ void ObjectMemory::addVMRefs()
 					// Shouldn't be zero count objects around that are not in the Zct
 					TRACESTREAM << ote << " (Oop " << LPVOID(ote) << "/" << i << ") had zero refs" << endl;
 					errors++;
-
-					if (!Interpreter::m_bAsyncGCDisabled && !IsReconcilingZct())
-					{
-						BOOL save = Interpreter::executionTrace;
-						Interpreter::executionTrace = 1;
-						recursiveFree(ote);
-						Interpreter::executionTrace = save;
-					}
 				}
 			}
 			else

--- a/GCPrim.cpp
+++ b/GCPrim.cpp
@@ -81,7 +81,7 @@ void Interpreter::asyncGC(DWORD gcFlags)
 	}
 #endif
 
-	ObjectMemory::asyncGC(gcFlags);
+	ObjectMemory::asyncGC(gcFlags, m_registers.m_stackPointer);
 }
 
 #ifndef _DEBUG
@@ -171,7 +171,7 @@ Oop* __fastcall Interpreter::primitiveOopsLeft()
 	// so any that are saved down in Smalltalk will be invalidated.
 	GrabAsyncProtect();
 	// It is OK for compact to perform additional GrabAsyncProtects()
-	SMALLINTEGER oopsLeft = ObjectMemory::compact();
+	SMALLINTEGER oopsLeft = ObjectMemory::compact(m_registers.m_stackPointer);
 	RelinquishAsyncProtect();
 
 	// compact() returns -1 if unable to reserve space for a new OT. This can happen

--- a/InterpRegisters.h
+++ b/InterpRegisters.h
@@ -29,7 +29,6 @@ struct InterpreterRegisters
 	ProcessOTE*			m_oteActiveProcess;
 
 public:
-	Process* activeProcess()		{ return m_pActiveProcess; }
 	Oop activeFrameOop()			{ return Oop(m_pActiveFrame)+1; }
 	StackFrame& activeFrame()		{ return *m_pActiveFrame; }
 
@@ -48,15 +47,12 @@ public:
 	void PrepareToSuspendProcess();	// Resize proc, update suspended frame, and store context to that frame
 	void PrepareToResumeProcess();	// Resize proc, update suspended frame, and store context to that frame
 	void ResizeProcess();
-
-	void IncStackRefs();
-	void DecStackRefs();
 };
 
 inline void InterpreterRegisters::ResizeProcess()
 {
 	HARDASSERT(m_pActiveProcess != NULL);
-	MWORD words = m_stackPointer - reinterpret_cast<const Oop*>(activeProcess()) + 1;
+	MWORD words = m_stackPointer - reinterpret_cast<const Oop*>(m_pActiveProcess) + 1;
 	m_oteActiveProcess->setSize(words*sizeof(MWORD));
 }
 

--- a/Interprt.h
+++ b/Interprt.h
@@ -192,13 +192,13 @@ public:
 	static void push(double d);
 
 	// To be used when pushing a known non-SmallInteger (skips the SmallInteger check)
-	template <typename T> static void pushObject(TOTE<T>* object)
+	static void pushObject(OTE* object)
 	{
 		push(reinterpret_cast<Oop>(object));
 	}
 
 	// Push newly created objects (add to Zct)
-	template <typename T> static void pushNewObject(TOTE<T>* object)
+	static void pushNewObject(OTE* object)
 	{
 		// Note that object is pushed on stack before being added to Zct, this means
 		// that on ZCT overflow the reconciliation will work correctly

--- a/Interprt.h
+++ b/Interprt.h
@@ -171,8 +171,8 @@ public:
 	static StackFrame* activeFrame();
 	static void __fastcall resizeActiveProcess();
 
-	static void IncStackRefs();
-	static void DecStackRefs();
+	static void IncStackRefs(Oop* const sp);
+	static void DecStackRefs(Oop* const sp);
 
 	// Stack
 

--- a/Interprt.inl
+++ b/Interprt.inl
@@ -195,28 +195,16 @@ inline void Interpreter::purgeObjectFromCaches(OTE* ote)
 		ace->oteArray = NULL;
 }
 
-inline void Interpreter::IncStackRefs()
+inline void Interpreter::IncStackRefs(Oop* const sp)
 {
-	m_registers.IncStackRefs();
-}
-
-inline void Interpreter::DecStackRefs()
-{
-	m_registers.DecStackRefs();
-}
-
-inline void InterpreterRegisters::IncStackRefs()
-{
-	Process* pProcess = activeProcess();
-	Oop* const sp = m_stackPointer;
-	for (Oop* pOop = pProcess->m_stack;pOop <= sp;pOop++)
+	Process* pProcess = actualActiveProcess();
+	for (Oop* pOop = pProcess->m_stack; pOop <= sp; pOop++)
 		ObjectMemory::countUp(*pOop);
 }
 
-inline void InterpreterRegisters::DecStackRefs()
+inline void Interpreter::DecStackRefs(Oop* const sp)
 {
-	Process* pProcess = activeProcess();
-	Oop* const sp = m_stackPointer;
+	Process* pProcess = actualActiveProcess();
 	for (Oop* pOop = pProcess->m_stack;pOop <= sp;pOop++)
 		ObjectMemory::countDown(*pOop);
 }

--- a/Interprt.inl
+++ b/Interprt.inl
@@ -37,7 +37,7 @@ inline void Interpreter::RelinquishAsyncProtect()
 inline void Interpreter::push(LPCSTR pStr)
 {
 	if (pStr)
-		pushNewObject(String::New(pStr));
+		pushNewObject((OTE*)String::New(pStr));
 	else
 		pushNil();
 }
@@ -45,14 +45,14 @@ inline void Interpreter::push(LPCSTR pStr)
 inline void Interpreter::pushHandle(HANDLE h)
 {
 	if (h)
-		pushNewObject(ExternalHandle::New(h));
+		pushNewObject((OTE*)ExternalHandle::New(h));
 	else
 		pushNil();
 }
 
 inline void Interpreter::push(double d)
 {
-	pushNewObject(Float::New(d));
+	pushNewObject((OTE*)Float::New(d));
 }
 
 inline void Interpreter::pushNil()

--- a/InterprtPrim.inl
+++ b/InterprtPrim.inl
@@ -37,13 +37,13 @@ inline void ST::Process::SetPrimitiveFailureData(SMALLINTEGER failureData)
 
 inline Oop* Interpreter::primitiveFailure(int failureCode)
 {
-	m_registers.activeProcess()->SetPrimitiveFailureCode(failureCode);
+	actualActiveProcess()->SetPrimitiveFailureCode(failureCode);
 	return NULL;
 }
 
 inline Oop* Interpreter::primitiveFailureWith(int failureCode, Oop failureData)
 {
-	Process* proc = m_registers.activeProcess();
+	Process* proc = actualActiveProcess();
 	proc->SetPrimitiveFailureCode(failureCode);
 	proc->SetPrimitiveFailureData(failureData);
 	return NULL;
@@ -52,7 +52,7 @@ inline Oop* Interpreter::primitiveFailureWith(int failureCode, Oop failureData)
 inline Oop* Interpreter::primitiveFailureWith(int failureCode, OTE* oteFailure)
 {
 	ASSERT(!ObjectMemoryIsIntegerObject(oteFailure));
-	Process* proc = m_registers.activeProcess();
+	Process* proc = actualActiveProcess();
 	proc->SetPrimitiveFailureCode(failureCode);
 	proc->SetPrimitiveFailureData(oteFailure);
 	return NULL;
@@ -61,7 +61,7 @@ inline Oop* Interpreter::primitiveFailureWith(int failureCode, OTE* oteFailure)
 // Just to avoid any confusion with Oop overload, give this one a different name
 inline Oop* Interpreter::primitiveFailureWithInt(int failureCode, SMALLINTEGER failureData)
 {
-	Process* proc = m_registers.activeProcess();
+	Process* proc = actualActiveProcess();
 	proc->SetPrimitiveFailureCode(failureCode);
 	proc->SetPrimitiveFailureData(failureData);
 	return NULL;

--- a/InterprtPrim.inl
+++ b/InterprtPrim.inl
@@ -10,8 +10,6 @@
 
 #include "STProcess.h"	// In order to be able to set primitive failure code
 
-#define primitiveSuccess() TRUE
-
 inline void ST::Process::SetPrimitiveFailureCode(SMALLINTEGER code)
 {
 	m_primitiveFailureCode = integerObjectOf(code);
@@ -37,36 +35,36 @@ inline void ST::Process::SetPrimitiveFailureData(SMALLINTEGER failureData)
 	m_primitiveFailureData = integerObjectOf(failureData);
 }
 
-inline BOOL Interpreter::primitiveFailure(int failureCode)
+inline Oop* Interpreter::primitiveFailure(int failureCode)
 {
 	m_registers.activeProcess()->SetPrimitiveFailureCode(failureCode);
-	return FALSE;
+	return NULL;
 }
 
-inline BOOL Interpreter::primitiveFailureWith(int failureCode, Oop failureData)
+inline Oop* Interpreter::primitiveFailureWith(int failureCode, Oop failureData)
 {
 	Process* proc = m_registers.activeProcess();
 	proc->SetPrimitiveFailureCode(failureCode);
 	proc->SetPrimitiveFailureData(failureData);
-	return FALSE;
+	return NULL;
 }
 
-inline BOOL Interpreter::primitiveFailureWith(int failureCode, OTE* oteFailure)
+inline Oop* Interpreter::primitiveFailureWith(int failureCode, OTE* oteFailure)
 {
 	ASSERT(!ObjectMemoryIsIntegerObject(oteFailure));
 	Process* proc = m_registers.activeProcess();
 	proc->SetPrimitiveFailureCode(failureCode);
 	proc->SetPrimitiveFailureData(oteFailure);
-	return FALSE;
+	return NULL;
 }
 
 // Just to avoid any confusion with Oop overload, give this one a different name
-inline BOOL Interpreter::primitiveFailureWithInt(int failureCode, SMALLINTEGER failureData)
+inline Oop* Interpreter::primitiveFailureWithInt(int failureCode, SMALLINTEGER failureData)
 {
 	Process* proc = m_registers.activeProcess();
 	proc->SetPrimitiveFailureCode(failureCode);
 	proc->SetPrimitiveFailureData(failureData);
-	return FALSE;
+	return NULL;
 }
 
 

--- a/InterprtProc.inl
+++ b/InterprtProc.inl
@@ -37,7 +37,7 @@ inline Process* Interpreter::activeProcess()
 // Always returns the active process, even if a new process is waiting
 inline Process* Interpreter::actualActiveProcess()
 {
-	return m_registers.activeProcess();
+	return m_registers.m_pActiveProcess;
 }
 
 // Always returns the active process, even if a new process is waiting
@@ -65,7 +65,7 @@ inline BOOL Interpreter::newProcessWaiting()
 inline void InterpreterRegisters::StoreSuspendedFrame()
 {
 	ResizeProcess();
-	activeProcess()->SetSuspendedFrame(activeFrameOop());
+	m_pActiveProcess->SetSuspendedFrame(activeFrameOop());
 }
 
 inline void InterpreterRegisters::StoreIPInFrame()

--- a/MemPrim.cpp
+++ b/MemPrim.cpp
@@ -50,7 +50,7 @@ Oop* __fastcall Interpreter::primitiveNewVirtual()
 	VirtualOTE* newObject = ObjectMemory::newVirtualObject(receiverClass, initialSize+fixedFields, maxSize+fixedFields);
 	*sp = reinterpret_cast<Oop>(newObject);
 	// No point saving down SP before potential Zct reconcile as the init & max args must be SmallIntegers
-	ObjectMemory::AddToZct(newObject);
+	ObjectMemory::AddToZct((OTE*)newObject);
 	return sp;
 }
 
@@ -81,6 +81,6 @@ Oop* __fastcall Interpreter::primitiveAllReferences(CompiledMethod&, unsigned ar
 	ArrayOTE* refs = ObjectMemory::referencesTo(receiver, includeWeakRefs);
 
 	*sp = reinterpret_cast<Oop>(refs);
-	ObjectMemory::AddToZct(refs);
+	ObjectMemory::AddToZct((OTE*)refs);
 	return sp;
 }

--- a/ObjMemPriv.inl
+++ b/ObjMemPriv.inl
@@ -16,16 +16,16 @@
 ///////////////////////////////////////////////////////////////////////////////
 // Low-level memory allocation
 
-inline void* ObjectMemory::allocChunk(MWORD chunkSize)
+inline POBJECT ObjectMemory::allocChunk(MWORD chunkSize)
 {
 	#if defined(PRIVATE_HEAP)
-		return ::HeapAlloc(m_hHeap, HEAP_NO_SERIALIZE, chunkSize);
+		return static_cast<POBJECT>(::HeapAlloc(m_hHeap, HEAP_NO_SERIALIZE, chunkSize));
 	#else
 		return malloc(chunkSize);
 	#endif
 }
 
-inline void* ObjectMemory::allocSmallChunk(MWORD chunkSize)
+inline POBJECT ObjectMemory::allocSmallChunk(MWORD chunkSize)
 {
 #ifdef MEMSTATS
 	++m_nSmallAllocated;
@@ -33,14 +33,14 @@ inline void* ObjectMemory::allocSmallChunk(MWORD chunkSize)
 
 	ASSERT(chunkSize <= MaxSmallObjectSize);
 	return chunkSize > MaxSizeOfPoolObject 
-		? __sbh_alloc_block(chunkSize) 
+		? static_cast<POBJECT>(__sbh_alloc_block(chunkSize))
 		: chunkSize == 0 
 				? NULL
 				: // Use Blair's very fast pools which tend to fragment a fair bit
 					spacePoolForSize(chunkSize).allocate();
 }
 
-inline void ObjectMemory::freeSmallChunk(void* pBlock, MWORD size)
+inline void ObjectMemory::freeSmallChunk(POBJECT pBlock, MWORD size)
 {
 #ifdef MEMSTATS
 	++m_nSmallFreed;

--- a/PerformPrim.cpp
+++ b/PerformPrim.cpp
@@ -256,7 +256,7 @@ Oop* __fastcall Interpreter::primitivePerformWithArgs()
 		// Receiver must have understood the message, but we had wrong 
 		// number of arguments, so reinstate the stack and fail the primitive
 		pop(argCount);
-		pushObject(m_oopMessageSelector);
+		pushObject((OTE*)m_oopMessageSelector);
 		// Argument array already has artificially increased ref. count
 		push(Oop(argumentArray));
 		m_oopMessageSelector = performSelector;

--- a/PointPrim.cpp
+++ b/PointPrim.cpp
@@ -72,9 +72,10 @@ Oop* __fastcall Interpreter::primitiveMakePoint(CompiledMethod&, unsigned argCou
 		obj->m_fields[i] = oopArg;
 	}
 
+	// Save down SP in case ZCT is reconciled on adding result, allowing unref'd args to be reclaimed
+	m_registers.m_stackPointer = sp;
 	*sp = reinterpret_cast<Oop>(oteObj);
-	ObjectMemory::AddToZct(reinterpret_cast<OTE*>(oteObj));
-	ASSERT(m_registers.m_stackPointer - sp == argCount);
+	ObjectMemory::AddToZct(oteObj);
 	return sp;
 }
 

--- a/PointPrim.cpp
+++ b/PointPrim.cpp
@@ -75,7 +75,7 @@ Oop* __fastcall Interpreter::primitiveMakePoint(CompiledMethod&, unsigned argCou
 	// Save down SP in case ZCT is reconciled on adding result, allowing unref'd args to be reclaimed
 	m_registers.m_stackPointer = sp;
 	*sp = reinterpret_cast<Oop>(oteObj);
-	ObjectMemory::AddToZct(oteObj);
+	ObjectMemory::AddToZct((OTE*)oteObj);
 	return sp;
 }
 

--- a/STBlockClosure.h
+++ b/STBlockClosure.h
@@ -20,7 +20,7 @@ namespace ST
 {
 	#include "STBlockInfo.h"
 
-	class BlockClosure //: public Object
+	class BlockClosure : public Object
 	{
 	public:
 		// Outer environment, or SmallInteger frame pointer if a method env.

--- a/STCollection.h
+++ b/STCollection.h
@@ -17,7 +17,7 @@
 
 namespace ST
 {
-	class Collection //: public Object
+	class Collection : public Object
 	{
 	public:
 		enum { FixedSize = 0 };		// FixedSize does not include Header

--- a/STContext.h
+++ b/STContext.h
@@ -27,7 +27,7 @@ typedef TOTE<ST::Context> ContextOTE;
 
 namespace ST
 {
-	class Context //: public Object
+	class Context : public Object
 	{
 	public:
 		// Outer environment, or SmallInteger frame pointer if a method env.

--- a/STExternal.h
+++ b/STExternal.h
@@ -36,7 +36,7 @@ struct COMThunk
 
 namespace ST
 {
-	class ExternalStructure //: public Object
+	class ExternalStructure : public Object
 	{
 	public:
 		BytesOTE*	m_contents;
@@ -47,13 +47,13 @@ namespace ST
 	};
 
 	// Really a subclass of ByteArray
-	class DWORDBytes //: public Object
+	class DWORDBytes : public Object
 	{
 	public:
 		DWORD m_dwValue;
 	};
 
-	class ExternalHandle //: public Object
+	class ExternalHandle : public Object
 	{
 		// ExternalHandle is really a variable byte subclass of length 4
 	public:
@@ -64,7 +64,7 @@ namespace ST
 		static Oop IntegerOrNew(HANDLE hValue);
 	};
 
-	class ExternalAddress //: public Object
+	class ExternalAddress : public Object
 	{
 		// ExternalAddress is really a variable byte subclass of length 4
 	public:
@@ -73,7 +73,7 @@ namespace ST
 		static AddressOTE* New(void* ptrValue);
 	};
 
-	class CallbackDescriptor //: public Object
+	class CallbackDescriptor : public Object
 	{
 	public:
 		Oop m_convention;
@@ -85,7 +85,7 @@ namespace ST
 	typedef TOTE<DescriptorBytes> DescriptorOTE;
 
 	// Not a real class, but useful all the same
-	class DescriptorBytes //: public Object
+	class DescriptorBytes : public Object
 	{
 	public:
 		BYTE	m_callingConvention;
@@ -97,7 +97,7 @@ namespace ST
 		static unsigned argsLen(DescriptorOTE* ote) { return ote->getSize() - offsetof(DescriptorBytes, m_args); }
 	};
 
-	class ExternalDescriptor //: public Object
+	class ExternalDescriptor : public Object
 	{
 	public:
 		DescriptorOTE* m_descriptor;	// Byte array of descriptor bytes

--- a/STMagnitude.h
+++ b/STMagnitude.h
@@ -17,7 +17,7 @@
 
 namespace ST
 {
-	class Magnitude //: public Object
+	class Magnitude : public Object
 	{
 	public:
 		enum { FixedSize = 0 };

--- a/STMethod.h
+++ b/STMethod.h
@@ -22,7 +22,7 @@ namespace ST
 {
 	#include "STMethodHeader.h"
 
-	class CompiledMethod //: public Object
+	class CompiledMethod : public Object
 	{
 	public:
 		STMethodHeader	m_header;		// Must look like a small integer

--- a/STObject.h
+++ b/STObject.h
@@ -15,33 +15,37 @@ enum { ObjectFixedSize = 0 };
 enum { ObjectHeaderSize = 0 };
 enum { ObjectByteSize = ObjectHeaderSize*sizeof(MWORD) };
 
-typedef void* POBJECT;
-
 // Turn off warning about zero length arrays
 #pragma warning ( disable : 4200)
 
 namespace ST
 {
+	class Object
+	{
+	};
+
 	// Not real Smalltalk classes
-	class VariantByteObject //: public Object
+	class VariantByteObject : public Object
 	{
 	public:
 		BYTE m_fields[];
 	};
 
-	class VariantCharObject //: public Object
+	class VariantCharObject : public Object
 	{
 	public:
 		char m_characters[];
 	};
 
 	// Useful for accessing an object by index
-	class VariantObject //: public Object
+	class VariantObject : public Object
 	{
 	public:
 		Oop				m_fields[];
 	};
 }
+
+typedef ST::Object* POBJECT;
 
 #if defined (VM)
 	#include "ote.h"

--- a/STProcess.h
+++ b/STProcess.h
@@ -120,10 +120,7 @@ namespace ST
 		}
 		void BasicClearNext();
 		void BasicSetNext(ProcessOTE* oteNext) { m_nextLink = oteNext; }
-		void SetNext(ProcessOTE* oteNext)
-		{
-			StorePointerWithValue(m_nextLink, oteNext);
-		}
+		void SetNext(ProcessOTE* oteNext);
 		Oop SuspendedFrame() const { return m_suspendedFrame; }
 		void SetSuspendedFrame(Oop intPointer)
 		{

--- a/STProcess.h
+++ b/STProcess.h
@@ -36,7 +36,7 @@ typedef TOTE<ST::ProcessorScheduler> SchedulerOTE;
 namespace ST
 {
 	// Really a subclass of Link, but VM doesn't care about that
-	class Process //: public Object
+	class Process : public Object
 	{
 	private:
 		// Really a member of Link superclass

--- a/STVirtualObject.h
+++ b/STVirtualObject.h
@@ -43,7 +43,7 @@ namespace ST
 		return mbi.RegionSize;
 	}
 
-	class VirtualObject // : public Object
+	class VirtualObject  : public Object
 	{
 	public:
 

--- a/SaveImage.cpp
+++ b/SaveImage.cpp
@@ -195,14 +195,14 @@ int __stdcall ObjectMemory::SaveImageFile(const char* szFileName, bool bBackup, 
 
 bool __stdcall ObjectMemory::SaveImage(obinstream& imageFile, const ImageHeader* pHeader, int nRet)
 {
-	EmptyZct();
+	EmptyZct(Interpreter::m_registers.m_stackPointer);
 	// Do the save.
 	bool bResult = imageFile.good() != 0 
 		&& (nRet == 3)
 		&& SaveObjectTable(imageFile, pHeader) 
 		&& SaveObjects(imageFile, pHeader) 
 		&& imageFile.flush().good();
-	PopulateZct();
+	PopulateZct(Interpreter::m_registers.m_stackPointer);
 	return bResult;
 }
 /*

--- a/SaveImage.cpp
+++ b/SaveImage.cpp
@@ -237,11 +237,11 @@ bool __stdcall ObjectMemory::SaveObjects(obinstream& imageFile, const ImageHeade
 				numObjects++;
 			#endif
 
-			void* obj = ote->m_location;
+			POBJECT obj = ote->m_location;
 
 			if (ote->heapSpace() == OTEFlags::VirtualSpace)
 			{
-				VirtualObject* vObj = reinterpret_cast<VirtualObject*>(obj);
+				VirtualObject* vObj = static_cast<VirtualObject*>(obj);
 				VirtualObjectHeader* pObjHeader = vObj->getHeader();
 
 				imageFile.write(pObjHeader, sizeof(VirtualObjectHeader));

--- a/SearchPrim.cpp
+++ b/SearchPrim.cpp
@@ -20,7 +20,7 @@
 
 // Uses object identity to locate the next occurrence of the argument in the receiver from
 // the specified index to the specified index
-BOOL __fastcall Interpreter::primitiveNextIndexOfFromTo()
+Oop* __fastcall Interpreter::primitiveNextIndexOfFromTo()
 {
 	Oop integerPointer = stackTop();
 	if (!ObjectMemoryIsIntegerObject(integerPointer))
@@ -103,8 +103,7 @@ BOOL __fastcall Interpreter::primitiveNextIndexOfFromTo()
 		answer = ZeroPointer; 		// Range is non-inclusive, cannot be there
 
 	stackValue(3) = answer;
-	pop(3);
-	return primitiveSuccess();
+	return primitiveSuccess(3);
 }
 
 // Initialize the Boyer-Moorer skip array
@@ -170,15 +169,16 @@ inline int __stdcall stringSearch(const BYTE* a, const int N, const BYTE* p, con
 
 // Uses object identity to locate the next occurrence of the argument in the receiver from
 // the specified index to the specified index
-BOOL __fastcall Interpreter::primitiveStringSearch()
+Oop* __fastcall Interpreter::primitiveStringSearch()
 {
-	Oop integerPointer = stackTop();
+	Oop* const sp = m_registers.m_stackPointer;
+	Oop integerPointer = *sp;
 	if (!ObjectMemoryIsIntegerObject(integerPointer))
 		return primitiveFailure(0);				// startingAt not an integer
 	const SMALLINTEGER startingAt = ObjectMemoryIntegerValueOf(integerPointer);
 
-	Oop oopSubString = stackValue(1);
-	BytesOTE* oteReceiver = reinterpret_cast<BytesOTE*>(stackValue(2));
+	Oop oopSubString = *(sp-1);
+	BytesOTE* oteReceiver = reinterpret_cast<BytesOTE*>(*(sp-2));
 
 	if (ObjectMemory::fetchClassOf(oopSubString) != oteReceiver->m_oteClass)
 		return primitiveFailure(2);
@@ -199,7 +199,6 @@ BOOL __fastcall Interpreter::primitiveStringSearch()
 					? -1 
 					: stringSearch(bytesReceiver->m_fields, N, bytesPattern->m_fields, M, startingAt - 1);
 	
-	stackValue(2) = ObjectMemoryIntegerObjectOf(nOffset+1);
-	pop(2);
-	return primitiveSuccess();
+	*(sp-2) = ObjectMemoryIntegerObjectOf(nOffset+1);
+	return sp-2;
 }

--- a/SnapshotPrim.cpp
+++ b/SnapshotPrim.cpp
@@ -28,7 +28,7 @@
 
 #pragma auto_inline(off)
 
-BOOL __fastcall Interpreter::primitiveSnapshot(CompiledMethod&, unsigned argCount)
+Oop* __fastcall Interpreter::primitiveSnapshot(CompiledMethod&, unsigned argCount)
 {
 	Oop arg = stackValue(argCount - 1);
 	char* szFileName;
@@ -94,8 +94,7 @@ BOOL __fastcall Interpreter::primitiveSnapshot(CompiledMethod&, unsigned argCoun
 	if (!saveResult)
 	{
 		// Success
-		popStack();
-		return primitiveSuccess();
+		return primitiveSuccess(1);
 	}
 	else
 	{

--- a/ToGoStub/SnapshotPrim.cpp
+++ b/ToGoStub/SnapshotPrim.cpp
@@ -23,7 +23,7 @@
 
 #pragma auto_inline(off)
 
-BOOL __fastcall Interpreter::primitiveSnapshot(CompiledMethod& , unsigned argCount)
+Oop* __fastcall Interpreter::primitiveSnapshot(CompiledMethod& , unsigned argCount)
 {
-	return FALSE;
+	return NULL;
 }

--- a/VMLib/Dolphin.natvis
+++ b/VMLib/Dolphin.natvis
@@ -72,7 +72,7 @@
   <Type Name="TOTE&lt;ST::Float&gt;">
     <DisplayString Condition="(Oop)this == Pointers.Nil">nil</DisplayString>
     <DisplayString Condition="m_flags.m_free">**a Freed Float**</DisplayString>
-    <DisplayString>{m_location->m_fValue,g}</DisplayString>
+    <DisplayString>{m_location->m_fValue,f}</DisplayString>
     <Expand HideRawView="true"></Expand>   
   </Type>
   <Type Name="TOTE&lt;ST::Character&gt;">

--- a/VMLib/VMLib.vcxproj
+++ b/VMLib/VMLib.vcxproj
@@ -201,12 +201,18 @@
       <PrecompiledHeader />
     </ClCompile>
   </ItemGroup>
+  <ItemDefinitionGroup>
+    <MASM>
+      <AdditionalDependencies>..\istasm.inc</AdditionalDependencies>
+    </MASM>
+    <ClCompile />
+    <ClCompile />
+  </ItemDefinitionGroup>
   <ItemGroup>
     <MASM Include="..\byteasm.asm" />
     <MASM Include="..\constobj.asm" />
     <MASM Include="..\ExternalBytes.asm" />
     <MASM Include="..\ExternalCall.asm" />
-    <MASM Include="..\flotprimasm.asm" />
     <MASM Include="..\primasm.asm" />
     <MASM Include="..\SmallIntPrim.asm" />
     <None Include="..\Interprt.inl" />

--- a/alloc.cpp
+++ b/alloc.cpp
@@ -537,10 +537,10 @@ inline ObjectMemory::FixedSizePool::FixedSizePool(unsigned nChunkSize) : m_pFree
 //	#pragma auto_inline(on)
 //#endif
 
-inline void* ObjectMemory::reallocChunk(void* pChunk, MWORD newChunkSize)
+inline POBJECT ObjectMemory::reallocChunk(POBJECT pChunk, MWORD newChunkSize)
 {
 	#ifdef PRIVATE_HEAP
-		return ::HeapReAlloc(m_hHeap, HEAP_NO_SERIALIZE, pChunk, newChunkSize);
+		return static_cast<POBJECT>(::HeapReAlloc(m_hHeap, HEAP_NO_SERIALIZE, pChunk, newChunkSize));
 	#else
 		void *oldPointer = pChunk;
 		void *newPointer = realloc(pChunk, newChunkSize);

--- a/byteasm.asm
+++ b/byteasm.asm
@@ -3478,7 +3478,9 @@ BEGINBYTECODE blockCopy
 	add		_IP, edx								; Jump to first byte code after block
 	call	BLOCKCOPY								; Create new block (returned in EAX)
 	LoadSPRegister									; blockCopy may have adjusted stack to remove copied values
-	PushNewObject <a>
+	mov	[_SP+OOPSIZE], eax
+	add	_SP, OOPSIZE
+	AddToZct <a>
 	DispatchByteCode
 ENDBYTECODE blockCopy
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/bytecde.cpp
+++ b/bytecde.cpp
@@ -556,7 +556,7 @@ void Interpreter::nonLocalReturnValueTo(Oop resultPointer, Oop framePointer)
 
 	StackFrame* pFrame = StackFrame::FromFrameOop(framePointer);
 	StackFrame* pActiveFrame = m_registers.m_pActiveFrame;
-	Process* pProcess = m_registers.activeProcess();
+	Process* pProcess = actualActiveProcess();
 	if (pFrame > pActiveFrame 
 			|| pFrame < reinterpret_cast<StackFrame*>(&pProcess->m_stack[0]))
 	{

--- a/bytecde.cpp
+++ b/bytecde.cpp
@@ -360,7 +360,7 @@ void __fastcall Interpreter::createActualMessage(const unsigned argCount)
 	Array* args = message->m_args->m_location;
 	
 	m_registers.m_stackPointer -= argCount;//-1;
-	const Oop* sp = m_registers.m_stackPointer;
+	Oop* const sp = m_registers.m_stackPointer;
 
 	// Transfer the arguments off the stack to the array
 	const unsigned loopEnd = argCount;
@@ -700,7 +700,7 @@ BlockOTE* __fastcall Interpreter::blockCopy(DWORD ext)
 	const unsigned nValuesToCopy = extension.copiedValuesCount;
 	if (nValuesToCopy > 0)
 	{
-		register Oop* sp = m_registers.m_stackPointer;
+		Oop* sp = m_registers.m_stackPointer;
 		unsigned i=0;
 		do
 		{

--- a/bytecde.cpp
+++ b/bytecde.cpp
@@ -371,7 +371,7 @@ void __fastcall Interpreter::createActualMessage(const unsigned argCount)
 		args->m_elements[i] = oopArg;
 	}
 
-	pushNewObject(messagePointer);
+	pushNewObject((OTE*)messagePointer);
 }
 
 #pragma code_seg(INTERP_SEG)
@@ -507,7 +507,7 @@ BlockOTE* __fastcall BlockClosure::New(unsigned copiedValuesCount)
 // not objects
 void Interpreter::invalidReturn(Oop resultPointer)
 {
-	pushObject(Pointers.Scheduler);	// Receiver of cannotReturn
+	pushObject((OTE*)Pointers.Scheduler);	// Receiver of cannotReturn
 	push(resultPointer);
 	sendSelectorArgumentCount(Pointers.CannotReturnSelector, 1);
 }

--- a/compact.cpp
+++ b/compact.cpp
@@ -117,7 +117,7 @@ size_t ObjectMemory::compact()
 		*first = *last;
 		moved++;
 		// Leave forwarding pointer in the old slot
-		last->m_location = first;
+		last->m_location = reinterpret_cast<POBJECT>(first);
 		last->beFree();
 		last->m_count = 0;
 		// Advance last as we've moved this slot
@@ -172,7 +172,7 @@ size_t ObjectMemory::compact()
 	while (cur < end)
 	{
 		HARDASSERT(cur->isFree());
-		cur->m_location = cur + 1;
+		cur->m_location = reinterpret_cast<POBJECT>(cur + 1);
 		cur++;
 	}
 

--- a/compact.cpp
+++ b/compact.cpp
@@ -80,10 +80,10 @@ void ObjectMemory::compactObject(OTE* ote)
 }
 
 // Perform a compacting GC
-size_t ObjectMemory::compact()
+size_t ObjectMemory::compact(Oop* const sp)
 {
 	TRACE("Compacting OT, size %d, free %d, ...\n", m_nOTSize, m_pOT + m_nOTSize - m_pFreePointerList);
-	EmptyZct();
+	EmptyZct(sp);
 
 	// First perform a normal GC
 	reclaimInaccessibleObjects(GCNormal);
@@ -177,7 +177,7 @@ size_t ObjectMemory::compact()
 	}
 
 	// Could do this before or after check refs, since that can account for Zct state
-	PopulateZct();
+	PopulateZct(sp);
 
 	CHECKREFERENCES
 

--- a/dealloc.cpp
+++ b/dealloc.cpp
@@ -35,7 +35,7 @@ inline void ObjectMemory::releasePointer(OTE* ote)
 //	if (!m_pFreePointerList)
 //		_asm int 3;
 
-	ote->m_location = m_pFreePointerList;
+	ote->m_location = reinterpret_cast<POBJECT>(m_pFreePointerList);
 	m_pFreePointerList = ote;
 
 #ifdef _DEBUG
@@ -50,7 +50,7 @@ inline void ObjectMemory::releasePointer(OTE* ote)
 //
 // These map directly onto C or Win32 heap
 
-void ObjectMemory::freeChunk(void* pObj)
+void ObjectMemory::freeChunk(POBJECT pObj)
 {
 #ifdef MEMSTATS
 	++m_nLargeFreed;

--- a/decode.cpp
+++ b/decode.cpp
@@ -408,7 +408,7 @@ ostream& operator<<(ostream& stream, const OTE* ote)
 
 SMALLUNSIGNED Interpreter::indexOfSP(Oop* sp)
 {
-	return m_registers.activeProcess()->indexOfSP(sp);
+	return actualActiveProcess()->indexOfSP(sp);
 }
 
 void DumpStackEntry(Oop* sp, Process* pProc, ostream& stream)
@@ -733,7 +733,7 @@ void Interpreter::DumpContext(ostream& logStream)
 	__try
 	{
 		logStream << "BP: ";
-		DumpBP(m_registers.m_basePointer, m_registers.activeProcess(), logStream);
+		DumpBP(m_registers.m_basePointer, actualActiveProcess(), logStream);
 	}
 	__except (EXCEPTION_EXECUTE_HANDLER)
 	{
@@ -778,7 +778,7 @@ void Interpreter::DumpStack(ostream& logStream, unsigned nStackDepth)
 	logStream << endl << "*----> Stack <----*" << endl;
 	__try
 	{
-		::DumpStack(m_registers.m_stackPointer, m_registers.activeProcess(), logStream, nStackDepth);
+		::DumpStack(m_registers.m_stackPointer, actualActiveProcess(), logStream, nStackDepth);
 	}
 	__except (EXCEPTION_EXECUTE_HANDLER)
 	{

--- a/extcall.cpp
+++ b/extcall.cpp
@@ -172,7 +172,7 @@ inline void Interpreter::push(LPCWSTR pStr)
 		StringOTE* stringPointer = reinterpret_cast<StringOTE*>(ObjectMemory::newUninitializedByteObject(Pointers.ClassString, len-1));
 		String* string = stringPointer->m_location;
 		::WideCharToMultiByte(CP_ACP,0,pStr,-1,string->m_characters,len,NULL,NULL);
-		pushNewObject(stringPointer);
+		pushNewObject((OTE*)stringPointer);
 	}
 	else
 		pushNil();
@@ -204,12 +204,12 @@ unsigned Interpreter::pushArgsAt(const ExternalDescriptor* descriptor, BYTE* lpP
 				break;
 
 			case ExtCallArgLPVOID:
-				pushNewObject(ExternalAddress::New(*(BYTE**)lpParms));
+				pushNewObject((OTE*)ExternalAddress::New(*(BYTE**)lpParms));
 				lpParms += sizeof(BYTE*);
 				break;
 
 			case ExtCallArgCHAR:
-				pushObject(Character::New(char(*lpParms)));
+				pushObject((OTE*)Character::New(char(*lpParms)));
 				lpParms += sizeof(MWORD);
 				break;
 
@@ -327,7 +327,7 @@ unsigned Interpreter::pushArgsAt(const ExternalDescriptor* descriptor, BYTE* lpP
 				break;
 
 			case ExtCallArgGUID:
-				pushNewObject(NewGUID(reinterpret_cast<GUID*>(lpParms)));
+				pushNewObject((OTE*)NewGUID(reinterpret_cast<GUID*>(lpParms)));
 				lpParms += sizeof(GUID);
 				break;
 
@@ -394,7 +394,7 @@ unsigned Interpreter::pushArgsAt(const ExternalDescriptor* descriptor, BYTE* lpP
 						punk->AddRef();
 						oteUnknown->beFinalizable();
 					}
-					pushNewObject(oteUnknown);
+					pushNewObject((OTE*)oteUnknown);
 					lpParms += sizeof(IUnknown*);
 				}
 				break;

--- a/finalize.cpp
+++ b/finalize.cpp
@@ -102,12 +102,16 @@ OTE* Interpreter::dequeueBereaved(VariantObject* out)
 		answer = Pointers.False;
 	else
 	{
-		for (unsigned i=0;i<OopsPerBereavementQEntry;i++)
+		for (unsigned i = 0; i < OopsPerBereavementQEntry; i++)
 		{
 			ObjectMemory::countDown(out->m_fields[i]);
 			out->m_fields[i] = m_qBereavements.Pop();
 		}
 		answer = Pointers.True;
+
+		ASSERT(!ObjectMemoryIsIntegerObject(out->m_fields[0]));
+		ASSERT(reinterpret_cast<OTE*>(out->m_fields[0])->isWeak());
+		ASSERT(ObjectMemoryIsIntegerObject(out->m_fields[1]));
 	}
 
 	return answer;

--- a/flotprim.cpp
+++ b/flotprim.cpp
@@ -98,7 +98,7 @@ Oop* __fastcall Interpreter::primitiveTruncated()
 			LONGLONG liTrunc = static_cast<LONGLONG>(fValue);
 			Oop truncated = Integer::NewSigned64(liTrunc);
 			*sp = truncated;
-			ObjectMemory::AddToZct(reinterpret_cast<OTE*>(truncated));
+			ObjectMemory::AddToZct(truncated);
 		}
 		else
 			return primitiveFailure(1);
@@ -205,9 +205,9 @@ Oop* Interpreter::primitiveFloatEqual()
 
 Oop* __fastcall Interpreter::primitiveDoublePrecisionFloatAt()
 {
-	Oop* const sp = m_registers.m_stackPointer;
+	Oop* sp = m_registers.m_stackPointer;
 
-	Oop integerPointer = *sp;
+	Oop integerPointer = *sp--;
 	if (!ObjectMemoryIsIntegerObject(integerPointer))
 	{
 		OTE* oteArg = reinterpret_cast<OTE*>(integerPointer);
@@ -215,7 +215,7 @@ Oop* __fastcall Interpreter::primitiveDoublePrecisionFloatAt()
 	}
 
 	SMALLUNSIGNED offset = ObjectMemoryIntegerValueOf(integerPointer);
-	OTE* receiver = reinterpret_cast<OTE*>(*(sp-1));
+	OTE* receiver = reinterpret_cast<OTE*>(*sp);
 
 	ASSERT(!ObjectMemoryIsIntegerObject(receiver));
 	ASSERT(receiver->isBytes());
@@ -242,17 +242,17 @@ Oop* __fastcall Interpreter::primitiveDoublePrecisionFloatAt()
 	}
 
 	oteResult->beImmutable();
-	*(sp - 1) = reinterpret_cast<Oop>(oteResult);
-	ObjectMemory::AddToZct(reinterpret_cast<OTE*>(oteResult));
-	return sp - 1;
+	*sp = reinterpret_cast<Oop>(oteResult);
+	ObjectMemory::AddToZct(oteResult);
+	return sp;
 }
 
 
 Oop* __fastcall Interpreter::primitiveSinglePrecisionFloatAt()
 {
-	Oop* const sp = m_registers.m_stackPointer;
+	Oop* sp = m_registers.m_stackPointer;
 
-	Oop integerPointer = *sp;
+	Oop integerPointer = *sp--;
 	if (!ObjectMemoryIsIntegerObject(integerPointer))
 	{
 		OTE* oteArg = reinterpret_cast<OTE*>(integerPointer);
@@ -260,7 +260,7 @@ Oop* __fastcall Interpreter::primitiveSinglePrecisionFloatAt()
 	}
 
 	SMALLUNSIGNED offset = ObjectMemoryIntegerValueOf(integerPointer);
-	OTE* receiver = reinterpret_cast<OTE*>(*(sp-1));
+	OTE* receiver = reinterpret_cast<OTE*>(*sp);
 
 	ASSERT(!ObjectMemoryIsIntegerObject(receiver));
 	ASSERT(receiver->isBytes());
@@ -287,9 +287,9 @@ Oop* __fastcall Interpreter::primitiveSinglePrecisionFloatAt()
 	}
 
 	oteResult->beImmutable();
-	*(sp - 1) = reinterpret_cast<Oop>(oteResult);
-	ObjectMemory::AddToZct(reinterpret_cast<OTE*>(oteResult));
-	return sp - 1;
+	*sp = reinterpret_cast<Oop>(oteResult);
+	ObjectMemory::AddToZct(oteResult);
+	return sp;
 }
 
 
@@ -412,8 +412,8 @@ Oop* __fastcall Interpreter::primitiveSinglePrecisionFloatAtPut()
 
 Oop* __fastcall Interpreter::primitiveLongDoubleAt()
 {
-	Oop* const sp = m_registers.m_stackPointer;
-	Oop integerPointer = *sp;
+	Oop* sp = m_registers.m_stackPointer;
+	Oop integerPointer = *sp--;
 	if (!ObjectMemoryIsIntegerObject(integerPointer))
 	{
 		OTE* oteArg = reinterpret_cast<OTE*>(integerPointer);
@@ -421,7 +421,7 @@ Oop* __fastcall Interpreter::primitiveLongDoubleAt()
 	}
 
 	SMALLUNSIGNED offset = ObjectMemoryIntegerValueOf(integerPointer);
-	OTE* receiver = reinterpret_cast<OTE*>(*(sp-1));
+	OTE* receiver = reinterpret_cast<OTE*>(*sp);
 
 	ASSERT(!ObjectMemoryIsIntegerObject(receiver));
 	ASSERT(receiver->isBytes());
@@ -458,8 +458,8 @@ Oop* __fastcall Interpreter::primitiveLongDoubleAt()
 	}
 
 	FloatOTE* oteResult = Float::New(fValue);
-	*(sp - 1) = reinterpret_cast<Oop>(oteResult);
-	ObjectMemory::AddToZct(reinterpret_cast<OTE*>(oteResult));
-	return sp - 1;
+	*sp = reinterpret_cast<Oop>(oteResult);
+	ObjectMemory::AddToZct(oteResult);
+	return sp;
 }
 

--- a/flotprimasm.asm
+++ b/flotprimasm.asm
@@ -14,43 +14,11 @@ PRIMPROC EQU PROC PUBLIC			; Export all the primtives defined herein
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Imports
 
-extern primitiveFailure0:near32
-
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Helpers
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Procedures
-
-; Converts a SmallInteger to a float, therefore no ref. counting for stack overwrite
-BEGINPRIMITIVE primitiveAsFloat
-	mov		eax, [_SP]
-	sar		eax, 1
-
-	; Use stack as working space to convert integer receiver to Float
-	push	eax
-	fild	DWORD PTR [esp]
-	pop		eax
-
-	; While we're waiting for the result, we can allocate the object to hold it
-	call	NEWFLOATOBJ
-	ASSUME	eax:PTR OTE					; Return value is OTE of new float
-	
-	mov		ecx, [eax].m_location
-	ASSUME	ecx:PTR Float
-
-	; Finally go and get the value (should now be ready)
-	fstp	QWORD PTR [ecx].m_fValue
-	ASSUME	ecx:NOTHING
-
-	ReplaceStackTopWithNew
-	
-	ASSUME	eax:DWORD					; Still contains Oop so will be non-zero for success
-	ret
-
-ENDPRIMITIVE primitiveAsFloat
-
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
@@ -58,7 +26,6 @@ ENDPRIMITIVE primitiveAsFloat
 PrimitiveFloatOp MACRO op
 
 	BEGINPRIMITIVE primitiveFloat&op
-		;mov		[INSTRUCTIONPOINTER], _IP			; Saved down IP in case of FP fault
 		mov		edx, [_SP]							; Load arg
 
 		mov		ecx, [_SP-4]						; Load receiver
@@ -98,9 +65,8 @@ PrimitiveFloatOp MACRO op
 			push	edx									; Temporarily place integer arg on stack
 			fi&op	DWORD PTR [esp]						; Apply op with integer arg (needs to be in memory)
 			
-			; Make space for result
+			; Make more space for result
 			push	eax
-			;pop		edx
 		.ENDIF
 
 		; Note that any FP fault may not occur until we attempt to store down the value, and therefore
@@ -111,11 +77,7 @@ PrimitiveFloatOp MACRO op
 		; may raise an FP exception for over/underflow. In the release build, we don't care about
 		; leaving around a little garbage for the next GC cycle to deal with when exceptions occur
 		IF 1; DEF _DEBUG
-			; Make temporary space on the machine stack to store the result
-			;sub		esp, SIZEOF QWORD
 			fstp	QWORD PTR [esp]
-			;fwait								; Overflow is possible at this point if too large
-			
 			call	NEWFLOAT8
 			fwait								; Overflow is possible at this point if too large
 		ELSE
@@ -133,14 +95,15 @@ PrimitiveFloatOp MACRO op
 		; If we get to here, then we know FP fault is not going to occur, so we can adjust ST stack
 
 		mov		[_SP-OOPSIZE], eax							; Overwrite receiver...
-		sub		_SP, OOPSIZE
 		AddToZct <a>
+		lea		eax, [_SP-OOPSIZE]							; primitiveSuccess(1)
 
 		ASSUME	eax:Oop
 		ret
 
 	primitiveFloatOpFailure0:
-		jmp		primitiveFailure0
+		xor		eax, eax
+		ret
 
 	ENDPRIMITIVE primitiveFloat&op
 ENDM
@@ -155,94 +118,5 @@ PrimitiveFloatOp <Add>
 PrimitiveFloatOp <Mul>
 PrimitiveFloatOp <Sub>
 PrimitiveFloatOp <Div>
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;
-
-PrimitiveFloatCmp MACRO op, mask
-
-	BEGINPRIMITIVE primitiveFloat&op
-		mov		ecx, [_SP-OOPSIZE]					; Load receiver
-		ASSUME	ecx:PTR OTE
-		mov		edx, [_SP]							; Load arg
-		test	dl, 1								; Arg is SmallInteger
-
-		mov		[INSTRUCTIONPOINTER], _IP			; Saved down IP in case of FP fault
-
-		mov		ecx, [ecx].m_location				; Load pointer to receiver object
-		ASSUME	ecx:PTR Float
-
-		jnz		cmpSmallInteger						; Skip to SmallInteger arg version
-
-		ASSUME	edx:PTR OTE
-
-		mov		eax, [edx].m_oteClass				; Load class of argument
-		ASSUME	eax:PTR OTE
-
-		; Arg is not a SmallInteger - only continue if a Float
-		mov		edx, [edx].m_location				; Load point to argument body into EDX
-
-		cmp		eax, [Pointers.ClassFloat]
-		jne		primitiveFloatCmpFailure0
-
-		ASSUME	edx:PTR Float
-
-		fld		[ecx].m_fValue
-		fcomp	[edx].m_fValue
-		fstsw	ax										;; Get the fp flags into AX
-
-		;; FP exception can't occur after this point, so we can now adjust stack
-		ASSUME	ecx:NOTHING
-
-		test	ah, mask							;; C? set
-		mov		eax, [oteTrue]
-		jnz		@F
-		add		eax, OTENTRYSIZE					;; False immediately follows true
-	@@:
-		mov		[_SP-OOPSIZE], eax					;; Overwrite receiver
-		PopStack									;; Pop arg
-		ret
-
-	primitiveFloatCmpFailure0:
-		jmp		primitiveFailure0
-		
-	cmpSmallInteger:
-		ASSUME	ecx:PTR Float
-		ASSUME	edx:SDWORD
-
-		sar		edx, 1								; Convert to integer value
-		PopStack									; Arg is SmallInteger, can't fail from here
-
-		fld		[ecx].m_fValue						; Push receiver on FP stack
-
-		; Now divide by the SmallInteger arg (have to move to memory to do this)
-
-		push	edx									; Temporarily place integer arg on stack
-		ficomp	DWORD PTR [esp]						; Apply op with integer arg (needs to be in memory)
-		pop		edx									; tidy away temp
-
-		ASSUME	edx:NOTHING
-		ASSUME	ecx:NOTHING
-
-	; Same as answerBoolean above
-		fnstsw	ax									; Get the fp flags into AX
-		test	ah, mask							; C? set
-		
-		mov		eax, [oteTrue]
-		jnz		@F
-		add		eax, OTENTRYSIZE					; False immediately follows true
-	@@:
-		mov		[_SP], eax							; Overwrite receiver
-		ret
-
-	ENDPRIMITIVE primitiveFloat&op
-ENDM
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-; Define the required comparisons using the macro. At present we only
-; need #< and #=
-
-PrimitiveFloatCmp <LT>, 1
-PrimitiveFloatCmp <EQ>, 64
 
 END

--- a/flotprimasm.asm
+++ b/flotprimasm.asm
@@ -95,10 +95,9 @@ PrimitiveFloatOp MACRO op
 		; If we get to here, then we know FP fault is not going to occur, so we can adjust ST stack
 
 		mov		[_SP-OOPSIZE], eax							; Overwrite receiver...
+		sub		_SP, OOPSIZE
 		AddToZct <a>
-		lea		eax, [_SP-OOPSIZE]							; primitiveSuccess(1)
-
-		ASSUME	eax:Oop
+		mov		eax, _SP
 		ret
 
 	primitiveFloatOpFailure0:

--- a/interfac.cpp
+++ b/interfac.cpp
@@ -634,7 +634,7 @@ int __stdcall Interpreter::callbackExceptionFilter(LPEXCEPTION_POINTERS info)
 		case EXCEPTION_ACCESS_VIOLATION:
 #if !defined(NO_GPF_TRAP)
 			// Handle errors due to stack/OT overflow
-			return memoryExceptionFilter(pExRec);
+			return memoryExceptionFilter(info);
 #endif
 		default:
 			return EXCEPTION_CONTINUE_SEARCH;

--- a/interfac.cpp
+++ b/interfac.cpp
@@ -339,26 +339,26 @@ void Interpreter::pushUnknown(Oop object)
 // Public methods for performing callbacks
 Oop	__stdcall Interpreter::perform(Oop receiver, SymbolOTE* selector TRACEPARM) /* throws SE_VMCALLBACKUNWIND */
 {
-	pushObject(Pointers.Scheduler);
+	pushObject((OTE*)Pointers.Scheduler);
 	pushUnknown(receiver);
-	pushObject(selector);
+	pushObject((OTE*)selector);
 	return callback(Pointers.callbackPerformSymbol, 2 TRACEARG(traceFlag));
 }
 
 Oop	__stdcall Interpreter::performWith(Oop receiver, SymbolOTE* selector, Oop arg TRACEPARM) /* throws SE_VMCALLBACKUNWIND */
 {
-	pushObject(Pointers.Scheduler);
+	pushObject((OTE*)Pointers.Scheduler);
 	pushUnknown(receiver);
-	pushObject(selector);
+	pushObject((OTE*)selector);
 	pushUnknown(arg);
 	return callback(Pointers.callbackPerformWithSymbol, 3 TRACEARG(traceFlag));
 }
 
 Oop	__stdcall Interpreter::performWithWith(Oop receiver, SymbolOTE* selector, Oop arg1, Oop arg2 TRACEPARM) /* throws SE_VMCALLBACKUNWIND */
 {
-	pushObject(Pointers.Scheduler);
+	pushObject((OTE*)Pointers.Scheduler);
 	pushUnknown(receiver);
-	pushObject(selector);
+	pushObject((OTE*)selector);
 	pushUnknown(arg1);
 	pushUnknown(arg2);
 	return callback(Pointers.callbackPerformWithWithSymbol, 4 TRACEARG(traceFlag));
@@ -366,9 +366,9 @@ Oop	__stdcall Interpreter::performWithWith(Oop receiver, SymbolOTE* selector, Oo
 
 Oop	__stdcall Interpreter::performWithWithWith(Oop receiver, SymbolOTE* selector, Oop arg1, Oop arg2, Oop arg3 TRACEPARM) /* throws SE_VMCALLBACKUNWIND */
 {
-	pushObject(Pointers.Scheduler);
+	pushObject((OTE*)Pointers.Scheduler);
 	pushUnknown(receiver);
-	pushObject(selector);
+	pushObject((OTE*)selector);
 	pushUnknown(arg1);
 	pushUnknown(arg2);
 	pushUnknown(arg3);
@@ -378,9 +378,9 @@ Oop	__stdcall Interpreter::performWithWithWith(Oop receiver, SymbolOTE* selector
 
 Oop	__stdcall Interpreter::performWithArguments(Oop receiver, SymbolOTE* selector, Oop anArray TRACEPARM) /* throws SE_VMCALLBACKUNWIND */
 {
-	pushObject(Pointers.Scheduler);
+	pushObject((OTE*)Pointers.Scheduler);
 	pushUnknown(receiver);
-	pushObject(selector);
+	pushObject((OTE*)selector);
 	ASSERT(ObjectMemory::fetchClassOf(anArray) == Pointers.ClassArray);
 	pushUnknown(anArray);
 	return callback(Pointers.callbackPerformWithArgumentsSymbol, 3 TRACEARG(traceFlag));
@@ -442,8 +442,8 @@ SymbolOTE* __stdcall Interpreter::NewSymbol(const char* name) /* throws SE_VMCAL
 	// to intern the symbol (Symbol intern: aString)
 	//
 
-	pushObject(Pointers.ClassSymbol);
-	pushNewObject(String::New(name));
+	pushObject((OTE*)Pointers.ClassSymbol);
+	pushNewObject((OTE*)String::New(name));
 	SymbolOTE* symbolPointer = reinterpret_cast<SymbolOTE*>(callback(Pointers.InternSelector, 1 TRACEARG(TraceOff)));
 	ASSERT(symbolPointer->m_oteClass == Pointers.ClassSymbol);
 	ASSERT(symbolPointer->m_count > 1);
@@ -649,7 +649,7 @@ inline DWORD __stdcall Interpreter::GenericCallbackMain(SMALLINTEGER id, BYTE* l
 	{
 		// All accesses to stack/OT allocations must be inside the
 		// memoryExceptionFilter to implement stack and OT growth-on-demand
-		pushObject(Pointers.Scheduler);
+		pushObject((OTE*)Pointers.Scheduler);
 		pushSmallInteger(id);
 		// Add sizeof(DWORD*) to the stack pointer as it includes the return address for
 		// the call which invoked the function
@@ -767,17 +767,17 @@ DWORD __fastcall Interpreter::VirtualCallbackMain(SMALLINTEGER offset, COMThunk*
 	DWORD result;
 	__try
 	{
-		Interpreter::pushObject(Pointers.Scheduler);
-		Interpreter::pushSmallInteger(offset+1);	// Smalltalk expects 1-based index
+		pushObject((OTE*)Pointers.Scheduler);
+		pushSmallInteger(offset+1);	// Smalltalk expects 1-based index
 		COMThunk* thisPtr = *args;
-		Interpreter::pushSmallInteger(thisPtr->id);
-		Interpreter::pushSmallInteger(thisPtr->subId);
+		pushSmallInteger(thisPtr->id);
+		pushSmallInteger(thisPtr->subId);
 		// Arguments are underneath thisPtr on stack
-		Interpreter::pushUIntPtr(reinterpret_cast<UINT_PTR>(args+1));
-		Oop oopAnswer = Interpreter::callback(Pointers.virtualCallbackSelector, 4 TRACEARG(Interpreter::TraceOff));
-		result = Interpreter::callbackResultFromOop(oopAnswer);
+		pushUIntPtr(reinterpret_cast<UINT_PTR>(args+1));
+		Oop oopAnswer = callback(Pointers.virtualCallbackSelector, 4 TRACEARG(Interpreter::TraceOff));
+		result = callbackResultFromOop(oopAnswer);
 	}
-	__except (Interpreter::callbackExceptionFilter(GetExceptionInformation()))
+	__except (callbackExceptionFilter(GetExceptionInformation()))
 	{
 		TRACESTREAM << "WARNING: Unwinding VirtualCallback(" << dec << offset << ',' << args << ')' << endl; 
 		result = static_cast<DWORD>(E_UNEXPECTED);

--- a/interfac.cpp
+++ b/interfac.cpp
@@ -324,7 +324,7 @@ void Interpreter::wakePendingCallbacks()
 
 void Interpreter::pushUnknown(Oop object)
 {
-	Interpreter::push(object);
+	push(object);
 	if (!ObjectMemoryIsIntegerObject(object))
 	{
 		OTE* ote = reinterpret_cast<OTE*>(object);

--- a/interprt.cpp
+++ b/interprt.cpp
@@ -204,7 +204,7 @@ HRESULT Interpreter::initializeAfterLoad()
 #endif
 
 	// Populate the ZCT with zero count objects in the startup process' stack
-	ObjectMemory::PopulateZct();
+	ObjectMemory::PopulateZct(m_registers.m_stackPointer);
 
 	// Set the callback pending count correctly to take account of any processes that were waiting
 	// on the pendingReturns Semaphore when the image was saved.
@@ -637,7 +637,7 @@ int Interpreter::memoryExceptionFilter(LPEXCEPTION_POINTERS pExInfo)
 	// pass control to the exception handler
 	DWORD dwAddress = pExRec->ExceptionInformation[1];
 
-	VirtualObjectHeader* pBase = m_registers.activeProcess()->getHeader();
+	VirtualObjectHeader* pBase = actualActiveProcess()->getHeader();
 	MWORD activeProcAlloc = pBase->getCurrentAllocation();
 	DWORD dwNext = DWORD(pBase) + activeProcAlloc;
 

--- a/istasm.inc
+++ b/istasm.inc
@@ -452,9 +452,9 @@ extern  METHODCACHE:PTR MethodCacheEntry
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; C++ member imports
 
-OBJECTTABLE EQU ?m_pOT@ObjectMemory@@2PAV?$TOTE@X@@A
+OBJECTTABLE EQU ?m_pOT@ObjectMemory@@2PAV?$TOTE@VObject@ST@@@@A
 EXTERN OBJECTTABLE:PTR OTE
-ZCT EQU ?m_pZct@ObjectMemory@@0PAPAV?$TOTE@X@@A
+ZCT EQU ?m_pZct@ObjectMemory@@0PAPAV?$TOTE@VObject@ST@@@@A
 EXTERN ZCT:near32
 ZCTENTRIES EQU ?m_nZctEntries@ObjectMemory@@0HA
 EXTERN ZCTENTRIES:near32
@@ -467,7 +467,6 @@ NEWDWORD				EQU		?NewDWORD@Interpreter@@SIPAV?$TOTE@VVariantByteObject@ST@@@@KPA
 extern NEWDWORD:near32
 LINEWSIGNED				EQU		?liNewSigned@LargeInteger@ST@@SIPAV?$TOTE@VLargeInteger@ST@@@@J@Z
 extern LINEWSIGNED:near32
-NEWSIGNED				EQU		NewSigned
 NEWFLOATOBJ				EQU		?New@Float@ST@@SGPAV?$TOTE@VFloat@ST@@@@XZ
 extern NEWFLOATOBJ:near32
 NEWFLOAT8				EQU		?New@Float@ST@@SGPAV?$TOTE@VFloat@ST@@@@N@Z
@@ -496,7 +495,7 @@ InterpRegisters STRUCT 2t
 	m_oopActiveProcess		POTE  ?
 InterpRegisters ENDS
 
-INTERPCONTEXT			EQU ?m_registers@Interpreter@@0UInterpreterRegisters@@A
+INTERPCONTEXT			EQU ?m_registers@Interpreter@@2UInterpreterRegisters@@A
 extern INTERPCONTEXT:InterpRegisters
 
 MESSAGE					EQU		?m_oopMessageSelector@Interpreter@@0PAV?$TOTE@VSymbol@ST@@@@A
@@ -683,23 +682,15 @@ CallCPP MACRO mangledName
 
 ENDM
 
-IFDEF _DEBUG
-	ADDTOZCT EQU ?AddToZct@ObjectMemory@@SIPAV?$TOTE@X@@PAV2@@Z
-	extern ADDTOZCT:near32
-ENDIF
-
-RECONCILEZCT EQU ?ReconcileZct@ObjectMemory@@SIPAV?$TOTE@X@@PAV2@@Z
+RECONCILEZCT EQU ?ReconcileZct@ObjectMemory@@SIPAV?$TOTE@VObject@ST@@@@PAV2@@Z
 extern RECONCILEZCT:near32
 
-AddToZct MACRO oopRegLetter:=<c>, stackP:=<_SP>
+AddToZct MACRO oopRegLetter, stackP:=<_SP>
 	LOCAL	fini
 	IFDIFI <e&oopRegLetter&x>, <ecx>				;; Don't move ecx onto itself
 		mov		ecx, e&oopRegLetter&x
 	ENDIF
-IF 0 ;DEF _DEBUG
-	StoreSPRegister									;; CPP SP register must be up to date in case of reconciliation
-	call	ADDTOZCT								;; Stick it in the Zct
-ELSE
+
 	IFDIFI <&stackP&>, <_SP>						;; Preserve the stack pointer value for later
 		push	stackP
 	ENDIF
@@ -712,13 +703,15 @@ ELSE
 	IFDIFI <&stackP&>, <_SP>
 		pop	stackP
 	ENDIF
-	.IF	(eax == DWORD PTR[ZCTHIGHWATER])			;; ZCT full?
+	IFDEF _DEBUG
 		mov		[STACKPOINTER], stackP			 	;; Save down interpreter stack pointer, e.g. for C routine
 		call	RECONCILEZCT
-	.ELSE
-		mov		eax, ecx							;; EAX must be OTE on exit from macro
-	.ENDIF
-ENDIF
+	ELSE
+		.IF	(eax == DWORD PTR[ZCTHIGHWATER])			;; ZCT full?
+			mov		[STACKPOINTER], stackP			 	;; Save down interpreter stack pointer, e.g. for C routine
+			call	RECONCILEZCT
+		.ENDIF
+	ENDIF
 fini:
 ENDM
 
@@ -726,7 +719,7 @@ ENDM
 ;; memory register is assumed to hold the correct value already.
 ;; I'd like to have achieved this using conditional assembly, but couldn't work out
 ;; how to do it in a reasonable amount of time.
-AddToZctNoSP MACRO oopRegLetter:=<c>
+AddToZctNoSP MACRO oopRegLetter
 	LOCAL	fini
 	IFDIFI <e&oopRegLetter&x>, <ecx>				;; Don't move ecx onto itself
 		mov		ecx, e&oopRegLetter&x
@@ -737,30 +730,30 @@ AddToZctNoSP MACRO oopRegLetter:=<c>
 	mov		DWORD PTR[edx+eax*4], ecx
 	inc		eax
 	mov		DWORD PTR[ZCTENTRIES], eax
-	.IF	(eax == DWORD PTR[ZCTHIGHWATER])			;; ZCT full?
+	IFDEF _DEBUG
 		call	RECONCILEZCT
-	.ELSE
-		mov		eax, ecx							;; EAX must be OTE on exit from macro
-	.ENDIF
+	ELSE
+		.IF	(eax == DWORD PTR[ZCTHIGHWATER])			;; ZCT full?
+			call	RECONCILEZCT
+		.ENDIF
+	ENDIF
 fini:
 ENDM
 
-;; Macro to count down an object in specified register - leaves Oop in eax, 
+;; Macro to count down an object in specified register
 ;; but object may have been deleted.
-;; Destroys ECX and EDX, and returns input in EAX
+;; Destroys ECX and EDX
 CountDownOopIn MACRO oopRegLetter:=<c>
 	LOCAL	fini
 	ASSUME	e&oopRegLetter&x:PTR OTE
 	test 	oopRegLetter&l, 1						;; Is is a SmallInteger
 	jnz 	fini									;; Yes, no further processing
-	ASSERTNEQU d, &oopRegLetter						;; If so, then it'll be trashed
+	ASSERTNEQU d, &oopRegLetter						;; Macro only works for count down of ECX, EAX, not EDX
 	mov		dl, [e&oopRegLetter&x].m_count
 	cmp		dl, 0ffh								;; Has count overflowed?
-;	cmp		[e&oopRegLetter&x].m_count, 0ffh
-	je		fini								;; Yes, do nothing
+	je		fini									;; Yes, do nothing
 	dec		dl
 	mov		[e&oopRegLetter&x].m_count, dl
-;	dec		[e&oopRegLetter&x].m_count
 
 	ASSUME	e&oopRegLetter&x:NOTHING
 	jnz		fini								;; Count not reduced to zero, skip deallocation
@@ -793,21 +786,6 @@ PushNewObject MACRO oopRegLetter:=<a>
 	AddToZct oopRegLetter
 ENDM
 
-ReplaceStackTopWithNew MACRO oopRegLetter:=<a>
-	IFDIFI <e&oopRegLetter&x>, <ecx>				;; Don't move ecx onto itself
-		mov		ecx, e&oopRegLetter&x
-	ENDIF
-	mov		[_SP], e&oopRegLetter&x					; Overwrite receiver class with new object
-	AddToZct oopRegLetter
-ENDM
-
-ReplaceStackTopWithNewOop MACRO oopRegLetter:=<a>
-	test	oopRegLetter&l, 1
-	mov		[_SP], e&oopRegLetter&x					; Overwrite receiver class with new object
-	jnz		@F	
-	AddToZct oopRegLetter
-@@:
-ENDM
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 CANTBEINTEGEROBJECT MACRO oopReg
@@ -853,6 +831,7 @@ GetIPOffsetUsing MACRO tempRegister
 	ENDIF
 ENDM
 
+
 PrimitiveFailureCode MACRO failureCode
 	mov		edx, [ACTIVEPROCESS]
 	xor		eax, eax
@@ -860,10 +839,9 @@ PrimitiveFailureCode MACRO failureCode
 	ret
 ENDM
 	
-PrimitiveFailureN MACRO failureCode
-	primitiveFailure&failureCode PROC
-		PrimitiveFailureCode failureCode
-	primitiveFailure&failureCode ENDP
+LocalPrimitiveFailure MACRO failureCode
+localPrimitiveFailure&failureCode:
+	PrimitiveFailureCode failureCode
 ENDM
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/istasm.inc
+++ b/istasm.inc
@@ -11,7 +11,7 @@ OPTION READONLY
 
 Oop			TYPEDEF		DWORD
 UINT		TYPEDEF		WORD
-HINSTANCE	TYPEDEF		UINT
+HINSTANCE	TYPEDEF		UINT 
 LPCSTR		TYPEDEF		PTR SBYTE
 HANDLE		TYPEDEF		DWORD
 BOOL		TYPEDEF		DWORD
@@ -682,24 +682,24 @@ CallCPP MACRO mangledName
 
 ENDM
 
-RECONCILEZCT EQU ?ReconcileZct@ObjectMemory@@SIPAV?$TOTE@VObject@ST@@@@PAV2@@Z
+RECONCILEZCT EQU ?ReconcileZct@ObjectMemory@@SIPAIXZ
 extern RECONCILEZCT:near32
 
 AddToZct MACRO oopRegLetter, stackP:=<_SP>
 	LOCAL	fini
-	IFDIFI <e&oopRegLetter&x>, <ecx>				;; Don't move ecx onto itself
-		mov		ecx, e&oopRegLetter&x
+	IFDIFI <e&oopRegLetter&x>, <eax>				;; Don't move eax onto itself
+		mov		eax, e&oopRegLetter&x
 	ENDIF
 
 	IFDIFI <&stackP&>, <_SP>						;; Preserve the stack pointer value for later
 		push	stackP
 	ENDIF
 	;; Only add OBJECTs (not SmallIntegers) with ref. count of zero to the Zct
-	mov		eax, DWORD PTR[ZCTENTRIES]
+	mov		ecx, DWORD PTR[ZCTENTRIES]
 	mov		edx, DWORD PTR[ZCT]
-	mov		DWORD PTR[edx+eax*4], ecx
-	inc		eax
-	mov		DWORD PTR[ZCTENTRIES], eax
+	mov		DWORD PTR[edx+ecx*4], eax
+	inc		ecx
+	mov		DWORD PTR[ZCTENTRIES], ecx
 	IFDIFI <&stackP&>, <_SP>
 		pop	stackP
 	ENDIF
@@ -707,7 +707,7 @@ AddToZct MACRO oopRegLetter, stackP:=<_SP>
 		mov		[STACKPOINTER], stackP			 	;; Save down interpreter stack pointer, e.g. for C routine
 		call	RECONCILEZCT
 	ELSE
-		.IF	(eax == DWORD PTR[ZCTHIGHWATER])			;; ZCT full?
+		.IF	(ecx == DWORD PTR[ZCTHIGHWATER])			;; ZCT full?
 			mov		[STACKPOINTER], stackP			 	;; Save down interpreter stack pointer, e.g. for C routine
 			call	RECONCILEZCT
 		.ENDIF
@@ -721,19 +721,19 @@ ENDM
 ;; how to do it in a reasonable amount of time.
 AddToZctNoSP MACRO oopRegLetter
 	LOCAL	fini
-	IFDIFI <e&oopRegLetter&x>, <ecx>				;; Don't move ecx onto itself
-		mov		ecx, e&oopRegLetter&x
+	IFDIFI <e&oopRegLetter&x>, <eax>				;; Don't move eax onto itself
+		mov		eax, e&oopRegLetter&x
 	ENDIF
 	;; Only add OBJECTs (not SmallIntegers) with ref. count of zero to the Zct
-	mov		eax, DWORD PTR[ZCTENTRIES]
+	mov		ecx, DWORD PTR[ZCTENTRIES]
 	mov		edx, DWORD PTR[ZCT]
-	mov		DWORD PTR[edx+eax*4], ecx
-	inc		eax
-	mov		DWORD PTR[ZCTENTRIES], eax
+	mov		DWORD PTR[edx+ecx*4], eax
+	inc		ecx
+	mov		DWORD PTR[ZCTENTRIES], ecx
 	IFDEF _DEBUG
 		call	RECONCILEZCT
 	ELSE
-		.IF	(eax == DWORD PTR[ZCTHIGHWATER])			;; ZCT full?
+		.IF	(ecx == DWORD PTR[ZCTHIGHWATER])			;; ZCT full?
 			call	RECONCILEZCT
 		.ENDIF
 	ENDIF
@@ -778,12 +778,6 @@ CountDownObjectIn MACRO oopRegLetter:=<c>
 	jnz		unRefdOop								;; Count not reduced to zero, skip deallocation
 	AddToZct oopRegLetter
 unRefdOop:
-ENDM
-
-PushNewObject MACRO oopRegLetter:=<a>
-	mov	[_SP+OOPSIZE], e&oopRegLetter&x
-	add	_SP, OOPSIZE
-	AddToZct oopRegLetter
 ENDM
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/objmem.cpp
+++ b/objmem.cpp
@@ -599,7 +599,7 @@ HRESULT ObjectMemory::allocateOT(unsigned reserve, unsigned commit)
 #endif
 
 		ote->beFree();
-		ote->m_location = ote+1;
+		ote->m_location = reinterpret_cast<POBJECT>(ote+1);
 	}
 
 	//TRACE("%d OTEs on free list\n", m_nFreeOTEs);
@@ -767,8 +767,10 @@ int ObjectMemory::OopsUsed()
 ///////////////////////////////////////////////////////////////////////////////
 #pragma code_seg(MEM_SEG)
 
-int ObjectMemory::gpFaultExceptionFilter(LPEXCEPTION_RECORD pExRec)
+int ObjectMemory::gpFaultExceptionFilter(LPEXCEPTION_POINTERS pExInfo)
 {
+	LPEXCEPTION_RECORD pExRec = pExInfo->ExceptionRecord;
+
 	// This "filter" is designed to handle GPFs only
 	ASSERT(pExRec->ExceptionCode == EXCEPTION_ACCESS_VIOLATION);
 
@@ -806,7 +808,7 @@ int ObjectMemory::gpFaultExceptionFilter(LPEXCEPTION_RECORD pExRec)
 					#endif
 
 					pLink->beFree();
-					pLink->m_location = pLink+1;
+					pLink->m_location = reinterpret_cast<POBJECT>(pLink+1);
 					pLink++;
 				}
 				m_nOTSize += extraOTEs;

--- a/objmem.h
+++ b/objmem.h
@@ -120,7 +120,7 @@ public:
 	static SMALLINTEGER OopsLeft();
 	static int __fastcall OopsUsed();
 	static unsigned GetOTSize();
-	static size_t compact();
+	static size_t compact(Oop* const sp);
 	static void HeapCompact();
 	static BYTE currentMark();
 
@@ -178,7 +178,7 @@ public:
 	static Oop* rootObjectPointers[];
 
 	enum GCFlags { GCNormal, GCNoWeakness };
-	static void asyncGC(DWORD flags);
+	static void asyncGC(DWORD flags, Oop* const sp);
 
 	static void markObject(OTE* ote);
 	static void MarkObjectsAccessibleFromRoot(OTE* ote);
@@ -192,7 +192,7 @@ public:
 	static void checkReferences();
 	static void addRefsFrom(OTE* ote);
 	static void checkPools();
-	static void checkStackRefs();
+	static void checkStackRefs(Oop* const sp);
 	static bool isValidOop(Oop);
 #endif
 
@@ -313,16 +313,16 @@ public:
 				GrowZct();
 			}
 			else
-				ReconcileZct(reinterpret_cast<OTE*>(ote));
+				ReconcileZct();
 		}
 	}
 
 	static void __fastcall AddToZct(Oop);
 
 	// Used by Interpreter when switching processes
-	static void EmptyZct();
-	static void PopulateZct();
-	static OTE* __fastcall ReconcileZct(OTE*);
+	static void EmptyZct(Oop* const sp);
+	static void PopulateZct(Oop* const sp);
+	static Oop* __fastcall ReconcileZct();
 #ifdef _DEBUG
 	static bool IsInZct(OTE*);
 	static void DumpZct();

--- a/objmem.h
+++ b/objmem.h
@@ -294,7 +294,7 @@ private:
 	static void ShrinkZct();
 
 public:
-	template <typename T> static void __fastcall AddToZct(TOTE<T>* ote)
+	static void __fastcall AddToZct(TOTE<Object>* ote)
 	{
 		HARDASSERT(m_nZctEntries >= 0);
 

--- a/ote.h
+++ b/ote.h
@@ -82,7 +82,7 @@ public:
 	__forceinline bool hasCurrentMark()						{ return m_flags.m_mark == ObjectMemory::currentMark(); }
 	__forceinline void setMark(BYTE mark)					{ m_flags.m_mark = mark; }
 
-	__forceinline MWORD getIndex()	const					{ return reinterpret_cast<const OTE*>(this) - ObjectMemory::m_pOT; }
+	__forceinline MWORD getIndex()	const					{ return this - reinterpret_cast<const TOTE<T>*>(ObjectMemory::m_pOT); }
 
 	__forceinline void countUp()							{ if (m_count < MAXCOUNT) m_count++; }
 
@@ -91,7 +91,7 @@ public:
 		HARDASSERT(m_count > 0);
 		if (m_count < MAXCOUNT)
 	 		if (--m_count == 0)
-				ObjectMemory::AddToZct(reinterpret_cast<OTE*>(this));
+				ObjectMemory::AddToZct(this);
 	}
 
 	__forceinline bool decRefs()							{ return (m_count < MAXCOUNT) && (--m_count == 0); }
@@ -140,12 +140,6 @@ public:
 	};
 };
 
-typedef TOTE<void> OTE;
-#ifndef POTE_DEFINED
-	typedef OTE* POTE;
-	#define POTE_DEFINED
-#endif
-
 #define isIntegerObject(objectPointer)	(Oop(objectPointer) & 1)
 #define integerObjectOf(value) 			(Oop(((SMALLINTEGER)(value) << 1) | 1))
 #define integerValueOf(objectPointer) 	(SMALLINTEGER(objectPointer) >> 1)
@@ -160,9 +154,14 @@ typedef TOTE<void> OTE;
 #define TwoPointer (integerObjectOf(2))
 #define ThreePointer (integerObjectOf(3))
 
-std::ostream& operator<<(std::ostream& stream, const OTE*);
-
 #include "STObject.h"
+typedef TOTE<ST::Object> OTE;
+#ifndef POTE_DEFINED
+typedef OTE* POTE;
+#define POTE_DEFINED
+#endif
+
+std::ostream& operator<<(std::ostream& stream, const OTE*);
 
 // Useful for overwriting structure members
 template <class T> TOTE<T>* StorePointerWithValue(TOTE<T>*& oteSlot, TOTE<T>* oteValue)

--- a/ote.h
+++ b/ote.h
@@ -91,7 +91,7 @@ public:
 		HARDASSERT(m_count > 0);
 		if (m_count < MAXCOUNT)
 	 		if (--m_count == 0)
-				ObjectMemory::AddToZct(this);
+				ObjectMemory::AddToZct((OTE*)this);
 	}
 
 	__forceinline bool decRefs()							{ return (m_count < MAXCOUNT) && (--m_count == 0); }
@@ -163,18 +163,8 @@ typedef OTE* POTE;
 
 std::ostream& operator<<(std::ostream& stream, const OTE*);
 
-// Useful for overwriting structure members
-template <class T> TOTE<T>* StorePointerWithValue(TOTE<T>*& oteSlot, TOTE<T>* oteValue)
-{
-	// Sadly compiler refuses to inline the count up code, and macro seems to generate
-	// bad code(!) so inline by hand
-	oteValue->countUp();			// Increase the reference count on stored object
-	oteSlot->countDown();
-	return (oteSlot = oteValue);
-}
-
-template <class T> TOTE<T>* NilOutPointer(TOTE<T>*& ote)
+template <class T> inline void NilOutPointer(TOTE<T>*& ote)
 {
 	ote->countDown();
-	return ote = reinterpret_cast<TOTE<T>*>(Pointers.Nil);
+	ote = reinterpret_cast<TOTE<T>*>(Pointers.Nil);
 }

--- a/primasm.asm
+++ b/primasm.asm
@@ -92,12 +92,16 @@ extern primitiveActivateMethod:near32
 extern primitiveReturnInstVar:near32
 extern primitiveSetInstVar:near32
 
-; Imports from flotprim.asm
+; Imports from flotprim.cpp
 primitiveAsFloat EQU ?primitiveAsFloat@Interpreter@@CIPAIXZ
 extern primitiveAsFloat:near32
+primitiveFloatAdd EQU ?primitiveFloatAdd@Interpreter@@CIPAIXZ
 extern primitiveFloatAdd:near32
+primitiveFloatSub EQU ?primitiveFloatSubtract@Interpreter@@CIPAIXZ
 extern primitiveFloatSub:near32
+primitiveFloatMul EQU ?primitiveFloatMultiply@Interpreter@@CIPAIXZ
 extern primitiveFloatMul:near32
+primitiveFloatDiv EQU ?primitiveFloatDivide@Interpreter@@CIPAIXZ
 extern primitiveFloatDiv:near32
 primitiveFloatEQ EQU ?primitiveFloatEqual@Interpreter@@CIPAIXZ
 extern primitiveFloatEQ:near32

--- a/primasm.asm
+++ b/primasm.asm
@@ -1067,7 +1067,8 @@ IFDEF _DEBUG
 stringAt:
 	; Should not get here
 	int 3
-	jmp primitiveFailure2
+	xor		eax, eax
+	ret
 ENDIF
 
 ENDPRIMITIVE primitiveAtCached
@@ -1318,7 +1319,8 @@ IFDEF _DEBUG
 cachedStringAtPut:
 	; Should not get here
 	int 3
-	jmp		primitiveFailure3
+	xor		eax, eax
+	ret
 ENDIF
 
 ENDPRIMITIVE primitiveAtPutCached
@@ -2509,13 +2511,12 @@ BEGINPRIMITIVE primitiveChangeBehavior
 	call	ALLOCATEBYTESNOZERO
 	ASSUME	eax:PTR OTE
 	mov		edx, [_SP]						; Reload SmallInteger receiver before overwritten
-	mov		ecx, eax
 	mov		[_SP], eax						; Replace SmallInteger at ToS receiver with new object
-	mov		eax, [eax].m_location			; Load address of new object
-	ASSUME	eax:PTR DWORDBytes
+	mov		ecx, [eax].m_location			; Load address of new object
+	ASSUME	ecx:PTR DWORDBytes
 	sar		edx, 1							; Convert receiver to real integer value
-	mov		[eax].m_value, edx				; Save receivers integer value into new object
-	AddToZct <c>
+	mov		[ecx].m_value, edx				; Save receivers integer value into new object
+	AddToZct <a>
 	mov		eax, _SP						; primitiveSuccess(0)
 	ret
 	ASSUME	eax:NOTHING

--- a/primitiv.cpp
+++ b/primitiv.cpp
@@ -54,7 +54,7 @@ Oop* __fastcall Interpreter::primitiveSmallIntegerPrintString()
 	{
 		StringOTE* oteResult = String::New(buffer);
 		*sp = reinterpret_cast<Oop>(oteResult);
-		ObjectMemory::AddToZct(reinterpret_cast<OTE*>(oteResult));
+		ObjectMemory::AddToZct(oteResult);
 		return sp;
 	}
 	else

--- a/primitiv.cpp
+++ b/primitiv.cpp
@@ -54,7 +54,7 @@ Oop* __fastcall Interpreter::primitiveSmallIntegerPrintString()
 	{
 		StringOTE* oteResult = String::New(buffer);
 		*sp = reinterpret_cast<Oop>(oteResult);
-		ObjectMemory::AddToZct(oteResult);
+		ObjectMemory::AddToZct((OTE*)oteResult);
 		return sp;
 	}
 	else

--- a/process.cpp
+++ b/process.cpp
@@ -1029,7 +1029,7 @@ ProcessOTE* Interpreter::resume(ProcessOTE* aProcess)
 			NilOutPointer(m_oteNewProcess);
 		}
 		else
-			StorePointerWithValue(m_oteNewProcess, aProcess);
+			ObjectMemory::storePointerWithValue((OTE*&)m_oteNewProcess, (OTE*)aProcess);
 
 		HARDASSERT(!proc->IsWaiting());
 	}
@@ -1091,6 +1091,10 @@ inline ProcessOTE* LinkedList::removeFirst()
 	return removedLink;
 }
 
+inline void Process::SetNext(ProcessOTE* oteNext)
+{
+	ObjectMemory::storePointerWithValue((OTE*&)m_nextLink, (OTE*)oteNext);
+}
 
 // Add link to end of list
 inline void LinkedList::addLast(ProcessOTE* aLink)
@@ -1098,7 +1102,7 @@ inline void LinkedList::addLast(ProcessOTE* aLink)
 	if (isEmpty())
 	{
 		// Incs the ref. count on aLink (current value is nil)
-		StorePointerWithValue(m_firstLink, aLink);
+		ObjectMemory::storePointerWithValue((OTE*&)m_firstLink, (OTE*)aLink);
 	}
 	else
 	{
@@ -1108,7 +1112,7 @@ inline void LinkedList::addLast(ProcessOTE* aLink)
 		// We add to the end of the list, so the current end of the list loses
 		// a reference from the list
 	}
-	StorePointerWithValue(m_lastLink, aLink);
+	ObjectMemory::storePointerWithValue((OTE*&)m_lastLink, (OTE*)aLink);
 }
 
 // Ref. count of removed (and returned) link will be one too high
@@ -1143,8 +1147,10 @@ ProcessOTE* LinkedList::remove(ProcessOTE* aLink)
 
 	// May have removed last link in list
 	if (aLink == m_lastLink)
+	{
 		// We DO remove the ref. from lists lastLink pointer
-		StorePointerWithValue(m_lastLink, prevLink);
+		ObjectMemory::storePointerWithValue((OTE*&)m_lastLink, (OTE*)prevLink);
+	}
 
 	Process* proc = aLink->m_location;
 

--- a/realloc.cpp
+++ b/realloc.cpp
@@ -26,7 +26,7 @@
 // These map directly onto C or Win32 heap
 
 
-inline void* ObjectMemory::reallocChunk(void* pChunk, MWORD newChunkSize)
+inline POBJECT ObjectMemory::reallocChunk(POBJECT pChunk, MWORD newChunkSize)
 {
 	#if defined(_DEBUG)
 		if (__sbh_find_block(pChunk) != NULL)
@@ -40,7 +40,7 @@ inline void* ObjectMemory::reallocChunk(void* pChunk, MWORD newChunkSize)
 	#endif
 
 	#ifdef PRIVATE_HEAP
-		return ::HeapReAlloc(m_hHeap, 0, pChunk, newChunkSize);
+		return static_cast<POBJECT>(::HeapReAlloc(m_hHeap, 0, pChunk, newChunkSize));
 	#else
 		return realloc(pChunk, newChunkSize);
 	#endif

--- a/thrdcall.cpp
+++ b/thrdcall.cpp
@@ -1009,7 +1009,7 @@ void OverlappedCall::ReincrementProcessReferences()
 ///////////////////////////////////////////////////////////////////////////////
 // Interpreter primitive 
 
-BOOL __fastcall Interpreter::primitiveAsyncDLL32Call(CompiledMethod& method, unsigned argCount)
+Oop* __fastcall Interpreter::primitiveAsyncDLL32Call(CompiledMethod& method, unsigned argCount)
 {
 	//inPrim = true;
 	//completed = false;
@@ -1057,5 +1057,5 @@ BOOL __fastcall Interpreter::primitiveAsyncDLL32Call(CompiledMethod& method, uns
 
 	//inPrim = false;
 
-	return TRUE;
+	return m_registers.m_stackPointer;
 }

--- a/wingui.cpp
+++ b/wingui.cpp
@@ -29,7 +29,7 @@ static HHOOK hHookOldCbtFilter;
 /////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 
-BOOL __fastcall Interpreter::primitiveHookWindowCreate()
+Oop* __fastcall Interpreter::primitiveHookWindowCreate()
 {
 	Oop argPointer = stackTop();
 	OTE* underConstruction = m_oteUnderConstruction;
@@ -71,8 +71,7 @@ BOOL __fastcall Interpreter::primitiveHookWindowCreate()
 			return primitiveFailureWith(0, argPointer);	// Invalid argument
 	}
 
-	popStack();
-	return TRUE;
+	return primitiveSuccess(1);
 }
 
 inline void Interpreter::subclassWindow(OTE* window, HWND hWnd)


### PR DESCRIPTION
Reduce overhead of calling primitives written in C++ vs assembler, and start to re-implement some primitives in C++, beginning with floating point comparison and arithmetic operations.