### PR TITLE
Allocate identity hash on demand rather than at object allocation time

### DIFF
--- a/ObjMemInit.cpp
+++ b/ObjMemInit.cpp
@@ -110,7 +110,7 @@ HRESULT ObjectMemory::Initialize()
 
 	FixedSizePool::Initialize();
 
-	m_nNextIdHash = 123;
+	m_nNextIdHash = 1;
 	m_nOTSize = OTDefaultSize;
 	m_nOTMax = OTDefaultMax;
 	//m_pOT does not need to be initialized

--- a/ObjMemPriv.inl
+++ b/ObjMemPriv.inl
@@ -64,11 +64,6 @@ inline void ObjectMemory::freeSmallChunk(POBJECT pBlock, MWORD size)
 ///////////////////////////////////////////////////////////////////////////////
 // Oop allocation
 
-inline hash_t ObjectMemory::nextIdentityHash()
-{
-	m_nNextIdHash = 1664525L * m_nNextIdHash + 1013904223L;
-	return static_cast<hash_t>(m_nNextIdHash & 0xFFFF);
-}
 inline OTE* __fastcall ObjectMemory::allocateOop(POBJECT pLocation)
 {
 	// OT is globally shared, so access must be in crit section
@@ -90,10 +85,7 @@ inline OTE* __fastcall ObjectMemory::allocateOop(POBJECT pLocation)
 	// Maintain the last used garbage collector mark to speed up collections
 	// Doing this will also reset the free bit and set the pointer bit
 	// so byte allocations will need to reset it
-
-	ote->m_flags = m_spaceOTEBits[OTEFlags::PoolSpace];
-	ASSERT(ote->m_count == 0);
-	ote->m_idHash = nextIdentityHash();
+	ote->m_dwFlags = *reinterpret_cast<BYTE*>(&m_spaceOTEBits[OTEFlags::PoolSpace]);
 
 	return ote;
 }

--- a/alloc.cpp
+++ b/alloc.cpp
@@ -301,7 +301,6 @@ VirtualOTE* ObjectMemory::newVirtualObject(BehaviorOTE* classPointer, MWORD init
 	ote->setSize(byteSize);
 	ote->m_oteClass = classPointer;
 	classPointer->countUp();
-	// We don't want to overwrite the identity hash allocated by allocateOop
 	ote->m_flags = m_spaceOTEBits[OTEFlags::VirtualSpace];
 	ASSERT(ote->isPointers());
 

--- a/objmem.h
+++ b/objmem.h
@@ -380,20 +380,15 @@ private:
 		static	unsigned	m_nAllocations;
 	};
 
-	// Object Table entry access routines
-	static OTE& ot(Oop objectPointer);
-
-	static OTE* headOfFreePointerListPut(OTE* ote);
-	static OTE* toFreePointerListAdd(OTE* ote);
-
 	static HRESULT __stdcall allocateOT(unsigned reserve, unsigned commit);
 
 	// Answer the index of the last occuppied OT entry
 	static unsigned __stdcall lastOTEntry();
 
 	static OTE* __fastcall allocateOop(POBJECT pLocation);
+public:
 	static hash_t nextIdentityHash();
-
+private:
 	// Memory allocators - these are very thin layers of C/Win32 heap
 	static void freeChunk(POBJECT pChunk);
 	static void freeSmallChunk(POBJECT pObj, MWORD size);
@@ -439,16 +434,10 @@ private:
 
 	static Oop corpsePointer();
 
-private: 
-	static void scheduleFinalization();
-	static void checkHospiceCrisis();
-
-
 private:
 	// Const obj support - very crude at present
 
 	static void* m_pConstObjs;
-	static BYTE* MakeObjConst(OTE* ote, BYTE*);
 public:
 	static DWORD __stdcall ProtectConstSpace(DWORD dwNewProtect);
 	static bool IsConstObj(void* ptr);
@@ -459,12 +448,9 @@ private:
 
 	static const char ISTHDRTYPE[4];
 
-	static bool __stdcall SavePointers(obinstream& imageFile, const ImageHeader*);
 	static bool __stdcall SaveObjectTable(obinstream& imageFile, const ImageHeader*);
 	static bool __stdcall SaveObjects(obinstream& imageFile, const ImageHeader*);
 	static bool __stdcall SaveImage(obinstream& imageFile, const ImageHeader*, int);
-
-	static void ShowExpiryDialog();
 
 	static HRESULT __stdcall LoadImage(ibinstream& imageFile, ImageHeader*);
 
@@ -1054,6 +1040,12 @@ inline BytesOTE* __fastcall ObjectMemory::newByteObject(BehaviorOTE* classPointe
 inline bool ObjectMemory::IsConstObj(void* ptr)
 {
 	return ptr >= m_pConstObjs && ptr < static_cast<BYTE*>(m_pConstObjs)+dwPageSize;
+}
+
+inline hash_t ObjectMemory::nextIdentityHash()
+{
+	m_nNextIdHash = 1664525L * m_nNextIdHash + 1013904223L;
+	return static_cast<hash_t>(m_nNextIdHash & 0xFFFF);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/ote.h
+++ b/ote.h
@@ -39,7 +39,6 @@ struct OTEFlags
 	BYTE	m_finalize	: 1;			// Should the object be finalized
 	BYTE 	m_weakOrZ	: 1;			// weak references if pointers, null term if bytes
 	BYTE 	m_space		: SPACEBITS;	// Memory space in which the object resides (used when deallocating)
-	//count_t	m_count;					// A byte ref. count
 };
 
 
@@ -132,7 +131,7 @@ public:
 	{
 		struct 
 		{
-			struct OTEFlags	m_flags;					// 16-bits of flags and ref. count
+			struct OTEFlags	m_flags;					// 8-bits of flags
 			count_t			m_count;
 			hash_t			m_idHash;					// identity hash value (16-bit)
 		};

--- a/primitiv.cpp
+++ b/primitiv.cpp
@@ -75,6 +75,28 @@ Oop* __fastcall Interpreter::primitiveSmallIntegerPrintString()
 
 #pragma code_seg(MEM_SEG)
 
+Oop* __fastcall Interpreter::primitiveIdentityHash()
+{
+	Oop* const sp = m_registers.m_stackPointer;
+	OTE* ote = (OTE*)*sp;
+	SMALLINTEGER idHash = ote->m_idHash;
+	if (idHash != 0)
+	{
+		*sp = ObjectMemoryIntegerObjectOf(idHash);
+	}
+	else
+	{
+		do
+		{
+			ote->m_idHash = ObjectMemory::nextIdentityHash();
+		} while (ote->m_idHash == 0);
+		*sp = ObjectMemoryIntegerObjectOf(ote->m_idHash);
+	}
+	return sp;
+}
+
+// Does not use successFlag, and returns a clean stack because can only succeed if
+// argument is a positive SmallInteger
 Oop* __fastcall Interpreter::primitiveResize()
 {
 	Oop integerPointer = stackTop();


### PR DESCRIPTION
This improves identity hash distribution when allocating large numbers of composite objects.