### PR TITLE
bitShift primitive fails unnecessarily for expression '0 bitShift: 32'

### DIFF
--- a/SmallIntPrim.asm
+++ b/SmallIntPrim.asm
@@ -763,16 +763,16 @@ arithmeticBitShift:
 
 	; Perform a left shift (more tricky sadly because of overflow detection)
 
-	cmp		ecx, 30							; We can't shift more than 30 places this way
+	sub		eax, 1							; Remove SmallInteger sign bit
+	jz		@F								; If receiver is zero, then result always zero
+
+	cmp		ecx, 30							; We can't shift more than 30 places this way, since receiver not zero
 	jge		bsLocalPrimitiveFailure1
 
 	; To avoid using a loop, we use the double precision shift first
 	; to detect potential overflow.
 	; This overflow check works, but is slow (about 12 cycles)
 	; since the majority of shifts are <= 16, perhaps should loop?
-	sub		eax, 1							; Remove SmallInteger sign bit
-	jz		@F								; If receiver is zero, then result always zero
-
 	push 	_BP								; We must preserve _BP
 	sar		edx, 31							; Sign extend part 2
 	inc		ecx								; Need to check space for sign too


### PR DESCRIPTION
Currently evaluating "0 bitShift: 32" causes the primitive to fail, because in the source code the  overflow test "cmp ecx, 30" is done before the zero test.

Reversing the order or the two checks will improve the runtime for a receiver zero by factor 10, since the primitive will no longer fail. The negative influence of the extra check in case of a a non-zero receiver with an argument >=30 should be negligible due to the failing primitive.
In all other cases the runtime should be the same as before.