### PR TITLE
Empty objects have null #yourAddress

### DIFF
--- a/ObjMemPriv.inl
+++ b/ObjMemPriv.inl
@@ -25,6 +25,8 @@ inline POBJECT ObjectMemory::allocChunk(MWORD chunkSize)
 	#endif
 }
 
+extern "C" ST::Object emptyObj;
+
 inline POBJECT ObjectMemory::allocSmallChunk(MWORD chunkSize)
 {
 #ifdef MEMSTATS
@@ -35,8 +37,8 @@ inline POBJECT ObjectMemory::allocSmallChunk(MWORD chunkSize)
 	return chunkSize > MaxSizeOfPoolObject 
 		? static_cast<POBJECT>(__sbh_alloc_block(chunkSize))
 		: chunkSize == 0 
-				? NULL
-				: // Use Blair's very fast pools which tend to fragment a fair bit
+				? &emptyObj
+				: // Use chunk pools, which are fast but can cause memory fragmentation
 					spacePoolForSize(chunkSize).allocate();
 }
 
@@ -56,7 +58,7 @@ inline void ObjectMemory::freeSmallChunk(POBJECT pBlock, MWORD size)
 	}
 	else
 	{
-		if (pBlock != NULL)
+		if (pBlock != &emptyObj)
 			spacePoolForSize(size).deallocate(pBlock);
 	}
 }

--- a/constobj.asm
+++ b/constobj.asm
@@ -17,10 +17,11 @@ INCLUDE IstAsm.Inc
 .data
 
 PUBLIC ?_Pointers@@3UVMPointers@@A
+PUBLIC _emptyObj
 
 VM$CNST SEGMENT PUBLIC 'DATA'
 ?_Pointers@@3UVMPointers@@A VMPointers <>
-_emptyStringObj SBYTE 4 DUP (?)				; ... String has null terminator so must pad to 4 bytes
+_emptyObj SBYTE 4 DUP (?)					; Used for all empty objects, including the empty String (actually of length 1, for the null terminator)
 _delimStringObj SBYTE 4 DUP (?)				; ... String 2+1 bytes, padded to 4
 _charObjs Character 256 DUP (<>)
 ; Pad out to fill one page


### PR DESCRIPTION
The VM does not allocate an object body for zero length objects. This
creates a needless special case in the image code. Use a common static
object body allocated in const space instead.