### PR TITLE
Dolphin #304: Incorrect tempsMap for full blocks nested in optimized blocks

### DIFF
--- a/Compiler/LexicalScope.h
+++ b/Compiler/LexicalScope.h
@@ -639,7 +639,8 @@ public:
 private:
 	void PropagateNeedsSelf();
 	void PropagateFarReturn();
-	void AddVisibleDeclsTo(DECLMAP&, bool bIncludeStack) const;
+	void AddVisibleDeclsTo(DECLMAP&) const;
+	void AddSharedDeclsTo(DECLMAP& allSharedDecls) const;
 	void CopyDownOptimizedDecls(Compiler*);
 };
 


### PR DESCRIPTION
Only shared outer temps should be added to the temps map for non-optimized blocks. All other temps that are visible are declared locally (arguments, copied outer temps, and local temps), and these should never be in the temps maps of nested blocks as they can only be copied into those blocks or passed as arguments. Local temps that are assigned to in a nested block are promoted to shared temps, so these should be in the temps map of the nested block. For convenience in the debugger, we add all shared temps in enclosing scopes, even if some of these are not referenced by a nested block itself.