### PR TITLE
Fix very slow compiler instance creation

### DIFF
--- a/Compiler/compiler.cpp
+++ b/Compiler/compiler.cpp
@@ -3515,17 +3515,19 @@ STDMETHODIMP_(POTE) Compiler::CompileForEval(IUnknown* piVM, Oop compilerOop, co
 	
 	CHECKREFERENCES
 		
-	char* prevLocale = NULL;
+	wchar_t* prevLocale = NULL;
 	__try
 	{
 #ifdef USE_VM_DLL
-		prevLocale = setlocale(LC_ALL, NULL);
-		if (prevLocale[0] == 'C' && prevLocale[1] == 0)
+		prevLocale = _wsetlocale(LC_ALL, L"C");
+		if (prevLocale[0] == L'C' && prevLocale[1] == 0)
+		{
 			prevLocale = NULL;
+		}
 		else
 		{
-			prevLocale = _strdup(prevLocale);
-			setlocale(LC_ALL, "C");
+			prevLocale = _wcsdup(prevLocale);
+			_wsetlocale(LC_ALL, L"C");
 		}
 #endif
 		
@@ -3560,14 +3562,14 @@ STDMETHODIMP_(POTE) Compiler::CompileForEval(IUnknown* piVM, Oop compilerOop, co
 #ifdef USE_VM_DLL
 		if (prevLocale != NULL)
 		{
-			setlocale(LC_ALL, prevLocale);
+			_wsetlocale(LC_ALL, prevLocale);
 			free(prevLocale);
 		}
 #endif
 	}
 	
 	CHECKREFERENCES
-		
+
 	return resultPointer;
 }
 


### PR DESCRIPTION
The compiler COM instance creation logic was very slow when the compiler
is not registered. This used not to matter, as the compiler in older
editions of Dolphin was expected to be registered, however this is usually
not the case in Dolphin7.