### PR TITLE
Pen & Touch non-op in Windows 8.1 & 10 (dolphinsmalltalk/dolphin#404)

### DIFF
--- a/environ.h
+++ b/environ.h
@@ -22,16 +22,16 @@
 
 	// Modify the following defines if you have to target a platform prior to the ones specified below.
 	// Refer to MSDN for the latest info on corresponding values for different platforms.
-	#ifndef WINVER				// Allow use of features specific to Windows XP and later (we no longer support 9x, 2000 or NT4)
-	#define WINVER 0x0501
+	#ifndef WINVER				// Allow use of features specific to Windows 8 and later
+	#define WINVER 0x0602
 	#endif
 
 	#ifndef _WIN32_WINNT		
-	#define _WIN32_WINNT 0x0501
+	#define _WIN32_WINNT WINVER
 	#endif						
 
 	#ifndef _WIN32_WINDOWS
-	#define _WIN32_WINDOWS 0x0501
+	#define _WIN32_WINDOWS WINVER
 	#endif
 
 	#ifndef _WIN32_IE


### PR DESCRIPTION
Build the VM with _WIN32_WINNT = 0x0602, so that it picks up the Windows 8
definition of QS_ALLINPUT, which includes extra flags for touch and pen
input.