### PR TITLE
Replace insecure CRT function exports with secure equivalents in stubs 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vs
 Debug
 Release
 VM Debug

--- a/ActiveXHost.idl
+++ b/ActiveXHost.idl
@@ -4,6 +4,9 @@
 // This file will be processed by the MIDL tool to
 // produce the type library (ActiveXHost.tlb) and marshalling code.
 
+// Disable warnings about inapplicable attributes in the standard include files
+midl_pragma warning(disable: 2402)
+
 import "oaidl.idl";
 import "ocidl.idl";
 
@@ -33,6 +36,9 @@ library ActiveXHost
 {
 	importlib("stdole32.tlb");
 	importlib("stdole2.tlb");
+
+	// Disable warning about attributes, etc, that cannot be represented in a type library, e.g. local
+	midl_pragma warning(disable: 2471)
 
 	[
 	object, local,

--- a/Compiler/Compiler.vcxproj
+++ b/Compiler/Compiler.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{35EB6247-4F53-4605-AA04-A9310AB3235B}</ProjectGuid>
     <RootNamespace>Compiler</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/ConsoleStub/Console.vcxproj
+++ b/ConsoleStub/Console.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{F6BBF41C-E4E0-4514-BA19-E248DE206820}</ProjectGuid>
     <RootNamespace>Console</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/ConsoleToGo/ConsoleToGo.def
+++ b/ConsoleToGo/ConsoleToGo.def
@@ -30,10 +30,9 @@ uncompress
 	_chmod
 	_clearfp
 	_close
-	_controlfp
+	_controlfp_s
 	_dup
 	_dup2
-	_ecvt
 	_eof
 	_errno
 	_fdopen
@@ -41,21 +40,18 @@ uncompress
 	_fileno
 	_finite
 	_fpclass
-	_gcvt
+	_gcvt_s
 	_getcwd
-	_i64toa
 	_isnan
 	_logb
-	_ltoa
-	_makepath
+	_makepath_s
 	_get_osfhandle
 	_open_osfhandle
-	_putenv
 	_rotl
 	_rotr
 	_setmode
 	_spawnvp
-	_splitpath
+	_splitpath_s
 	_stricmp
 	_stricoll
 	_strnicmp
@@ -75,10 +71,9 @@ uncompress
 	fgetc
 	fgets
 	floor
-	fopen
+	fopen_s
 	fputc
-	fread
-	freopen
+	fread_s
 	frexp
 	fseek
 	ftell
@@ -92,8 +87,6 @@ uncompress
 	log
 	log10
 	memcmp
-	memcpy
-	memmove
 	memset
 	modf
 	pow
@@ -103,12 +96,12 @@ uncompress
 	sin
 	sqrt
 	srand
-	strcat
+	strcat_s
 	strcmp
 	strcspn
 	strerror
 	strncmp
-	strncpy
+	strncpy_s
 	strpbrk
 	tan
 	ungetc

--- a/ConsoleToGo/ConsoleToGo.vcxproj
+++ b/ConsoleToGo/ConsoleToGo.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{714480A5-0779-4C59-8A08-856E5C34AC37}</ProjectGuid>
     <RootNamespace>ConsoleToGo</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/DevRes.vcxproj
+++ b/DevRes.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{FAB6154D-5E54-4967-B55D-F5AEE5DC18F0}</ProjectGuid>
     <RootNamespace>DevRes</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/DolphinLib.vcxproj
+++ b/DolphinLib.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{241D4E3E-44C0-40B7-BE1B-5249916FE631}</ProjectGuid>
     <RootNamespace>DolphinLib</RootNamespace>
     <Keyword>MakeFileProj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/DolphinSureCrypto/DolphinSureCrypto.vcxproj
+++ b/DolphinSureCrypto/DolphinSureCrypto.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{6D089C23-9091-47DB-B092-93D387425DC0}</ProjectGuid>
     <RootNamespace>DolphinSureCrypto</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/GUIStub/Stub.vcxproj
+++ b/GUIStub/Stub.vcxproj
@@ -14,7 +14,7 @@
     <ProjectName>GUIStub</ProjectName>
     <ProjectGuid>{47007458-C534-493F-9A4C-936E5E0C91C8}</ProjectGuid>
     <RootNamespace>GUIStub</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/InProcStub/InProcStub.vcxproj
+++ b/InProcStub/InProcStub.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{CD85B8FA-6C9E-45C0-AFC8-0A79A7E5D0F7}</ProjectGuid>
     <RootNamespace>InProcStub</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/InProcToGo/IPToGo.def
+++ b/InProcToGo/IPToGo.def
@@ -41,10 +41,9 @@ uncompress
 	_chmod
 	_clearfp
 	_close
-	_controlfp
+	_controlfp_s
 	_dup
 	_dup2
-	_ecvt
 	_eof
 	_errno
 	_fdopen
@@ -52,21 +51,18 @@ uncompress
 	_fileno
 	_finite
 	_fpclass
-	_gcvt
+	_gcvt_s
 	_getcwd
-	_i64toa
 	_isnan
 	_logb
-	_ltoa
-	_makepath
+	_makepath_s
 	_get_osfhandle
 	_open_osfhandle
-	_putenv
 	_rotl
 	_rotr
 	_setmode
 	_spawnvp
-	_splitpath
+	_splitpath_s
 	_stricmp
 	_stricoll
 	_strnicmp
@@ -86,10 +82,9 @@ uncompress
 	fgetc
 	fgets
 	floor
-	fopen
+	fopen_s
 	fputc
-	fread
-	freopen
+	fread_s
 	frexp
 	fseek
 	ftell
@@ -103,8 +98,6 @@ uncompress
 	log
 	log10
 	memcmp
-	memcpy
-	memmove
 	memset
 	modf
 	pow
@@ -114,12 +107,12 @@ uncompress
 	sin
 	sqrt
 	srand
-	strcat
+	strcat_s
 	strcmp
 	strcspn
 	strerror
 	strncmp
-	strncpy
+	strncpy_s
 	strpbrk
 	tan
 	ungetc

--- a/InProcToGo/InProcToGo.vcxproj
+++ b/InProcToGo/InProcToGo.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{90C32F90-C0B1-46FE-BACE-FB6566EB6F3C}</ProjectGuid>
     <RootNamespace>InProcToGo</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/Launcher/Dull.vcxproj
+++ b/Launcher/Dull.vcxproj
@@ -14,7 +14,7 @@
     <ProjectName>Launcher</ProjectName>
     <ProjectGuid>{A8454911-DE25-451D-AC38-1B6B058C050D}</ProjectGuid>
     <RootNamespace>Launcher</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/ToGoLib/ToGoLib.vcxproj
+++ b/ToGoLib/ToGoLib.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{50AB410B-7D13-43FF-B426-FB02CA3FEF86}</ProjectGuid>
     <RootNamespace>VMLib</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/ToGoStub/GuiToGo.vcxproj
+++ b/ToGoStub/GuiToGo.vcxproj
@@ -14,7 +14,7 @@
     <ProjectName>GUIToGo</ProjectName>
     <ProjectGuid>{12B536BA-143E-4F38-BD96-77B35467DB13}</ProjectGuid>
     <RootNamespace>ToGoStub</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/ToGoStub/togo.def
+++ b/ToGoStub/togo.def
@@ -37,10 +37,9 @@ uncompress
 	_chmod
 	_clearfp
 	_close
-	_controlfp
+	_controlfp_s
 	_dup
 	_dup2
-	_ecvt
 	_eof
 	_errno
 	_fdopen
@@ -48,21 +47,18 @@ uncompress
 	_fileno
 	_finite
 	_fpclass
-	_gcvt
+	_gcvt_s
 	_getcwd
-	_i64toa
 	_isnan
 	_logb
-	_ltoa
-	_makepath
+	_makepath_s
 	_get_osfhandle
 	_open_osfhandle
-	_putenv
 	_rotl
 	_rotr
 	_setmode
 	_spawnvp
-	_splitpath
+	_splitpath_s
 	_stricmp
 	_stricoll
 	_strnicmp
@@ -82,10 +78,9 @@ uncompress
 	fgetc
 	fgets
 	floor
-	fopen
+	fopen_s
 	fputc
-	fread
-	freopen
+	fread_s
 	frexp
 	fseek
 	ftell
@@ -99,8 +94,6 @@ uncompress
 	log
 	log10
 	memcmp
-	memcpy
-	memmove
 	memset
 	modf
 	pow
@@ -110,12 +103,12 @@ uncompress
 	sin
 	sqrt
 	srand
-	strcat
 	strcmp
+	strcat_s
 	strcspn
 	strerror
 	strncmp
-	strncpy
+	strncpy_s
 	strpbrk
 	tan
 	ungetc

--- a/VMLib/VMLib.vcxproj
+++ b/VMLib/VMLib.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{BC5D162D-46BC-42CF-85DB-CB715EE8517E}</ProjectGuid>
     <RootNamespace>VMLib</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/dll.vcxproj
+++ b/dll.vcxproj
@@ -14,7 +14,7 @@
     <ProjectName>VM</ProjectName>
     <ProjectGuid>{382ABBF3-B32D-4D77-B303-346AA146921C}</ProjectGuid>
     <RootNamespace>VM</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">


### PR DESCRIPTION
This is step 2 of a change across the Dolphin and DolphinVM repos.

Note that the Windows SDK version is also updated to the latest (default) version installed with VS2017.
The VM still builds with VS2015 as it is still using the v140 toolset, but will either need to be retargeted locally, or the later SDK installed (or install VS2017).

In other words, options for building are:
- VS2015 with 10.0.15063 SDK
- VS2017 with optional v140 toolset installed
