### PR TITLE
Add primitives for reading 64-bit ints from a byte array

### DIFF
--- a/Interprt.h
+++ b/Interprt.h
@@ -561,6 +561,9 @@ private:
 		static Oop* __fastcall primitiveSWORDAtPut();
 	#endif
 
+	static Oop* __fastcall primitiveQWORDAt();
+	static Oop* __fastcall primitiveSQWORDAt();
+
 	// Floating point number accessors
 	static Oop* __fastcall primitiveSinglePrecisionFloatAt();
 	static Oop* __fastcall primitiveSinglePrecisionFloatAtPut();

--- a/STMethodHeader.h
+++ b/STMethodHeader.h
@@ -23,7 +23,7 @@ typedef enum {
 	PRIMITIVE_RETURN_INSTVAR = 6,
 	PRIMITIVE_SET_INSTVAR = 7,
 	PRIMITIVE_RETURN_STATIC_ZERO=8,
-	PRIMITIVE_MAX = 192		// Theoretical maximum is 255, but table is smaller
+	PRIMITIVE_MAX = 224		// Theoretical maximum is 255, but table is smaller
 } STPrimitives;
 
 typedef struct STMethodHeader

--- a/bytecde.cpp
+++ b/bytecde.cpp
@@ -244,7 +244,7 @@ MethodOTE* __fastcall Interpreter::findNewMethodInClass(BehaviorOTE* classPointe
 
 #pragma code_seg(INTERP_SEG)
 
-extern "C" DWORD primitivesTable[192];
+extern "C" DWORD primitivesTable[PRIMITIVE_MAX];
 
 inline DWORD LookupMethodPrimitive(MethodOTE* oteMethod)
 {

--- a/largeintprim.cpp
+++ b/largeintprim.cpp
@@ -2355,3 +2355,52 @@ ArrayOTE* __stdcall liDivExport(LargeIntegerOTE* oteU, LargeIntegerOTE* oteV)
 }
 	
 #endif
+
+
+Oop* __fastcall Interpreter::primitiveQWORDAt()
+{
+	Oop* const sp = m_registers.m_stackPointer - 1;
+	BytesOTE* oteReceiver = reinterpret_cast<BytesOTE*>(*sp);
+	const Oop oopOffset = sp[1];
+	if (ObjectMemoryIsIntegerObject(oopOffset))
+	{
+		SMALLUNSIGNED offset = ObjectMemoryIntegerValueOf(oopOffset);
+		if (static_cast<SMALLINTEGER>(offset) >= 0 && offset + sizeof(ULONGLONG) <= oteReceiver->bytesSize())
+		{
+			VariantByteObject* pBytes = oteReceiver->m_location;
+			Oop result = Integer::NewUnsigned64(*(ULONGLONG*)(pBytes->m_fields + offset));
+
+			*sp = result;
+			ObjectMemory::AddToZct(result);
+			return sp;
+		}
+		else
+			return primitiveFailure(PrimitiveFailureBoundsError);
+	}
+
+	return primitiveFailure(PrimitiveFailureNonInteger);
+}
+
+Oop* __fastcall Interpreter::primitiveSQWORDAt()
+{
+	Oop* const sp = m_registers.m_stackPointer - 1;
+	BytesOTE* oteReceiver = reinterpret_cast<BytesOTE*>(*sp);
+	const Oop oopOffset = sp[1];
+	if (ObjectMemoryIsIntegerObject(oopOffset))
+	{
+		SMALLUNSIGNED offset = ObjectMemoryIntegerValueOf(oopOffset);
+		if (static_cast<SMALLINTEGER>(offset) >= 0 && offset + sizeof(LONGLONG) <= oteReceiver->bytesSize())
+		{
+			VariantByteObject* pBytes = oteReceiver->m_location;
+			Oop result = Integer::NewSigned64(*(LONGLONG*)(pBytes->m_fields + offset));
+
+			*sp = result;
+			ObjectMemory::AddToZct(result);
+			return sp;
+		}
+		else
+			return primitiveFailure(PrimitiveFailureBoundsError);
+	}
+
+	return primitiveFailure(PrimitiveFailureNonInteger);
+}

--- a/primasm.asm
+++ b/primasm.asm
@@ -131,6 +131,11 @@ extern primitiveIndirectSWORDAtPut:near32
 extern primitiveByteAtAddress:near32
 extern primitiveByteAtAddressPut:near32
 
+primitiveQWORDAt EQU ?primitiveQWORDAt@Interpreter@@CIPAIXZ
+extern primitiveQWORDAt:near32
+primitiveSQWORDAt EQU ?primitiveSQWORDAt@Interpreter@@CIPAIXZ
+extern primitiveSQWORDAt:near32
+
 ; Imports from ExternalCall.asm
 extern primitiveDLL32Call:near32
 extern primitiveVirtualCall:near32
@@ -579,8 +584,41 @@ DWORD		primitiveIndirectSDWORDAtPut					; case 187  Will be primitiveIndirectInt
 DWORD		primitiveReplacePointers						; case 188
 DWORD		primitiveMicrosecondClockValue					; case 189
 DWORD		primitiveNewFromStack							; case 190
-DWORD		unusedPrimitive									; case 191
-DWORD		unusedPrimitive									; case 192
+DWORD		primitiveQWORDAt								; case 191
+DWORD		primitiveSQWORDAt								; case 192
+DWORD		unusedPrimitive									; case 193
+DWORD		unusedPrimitive									; case 194
+DWORD		unusedPrimitive									; case 195
+DWORD		unusedPrimitive									; case 196
+DWORD		unusedPrimitive									; case 197
+DWORD		unusedPrimitive									; case 198
+DWORD		unusedPrimitive									; case 199
+DWORD		unusedPrimitive									; case 200
+DWORD		unusedPrimitive									; case 201
+DWORD		unusedPrimitive									; case 202
+DWORD		unusedPrimitive									; case 203
+DWORD		unusedPrimitive									; case 204
+DWORD		unusedPrimitive									; case 205
+DWORD		unusedPrimitive									; case 206
+DWORD		unusedPrimitive									; case 207
+DWORD		unusedPrimitive									; case 208
+DWORD		unusedPrimitive									; case 209
+DWORD		unusedPrimitive									; case 210
+DWORD		unusedPrimitive									; case 211
+DWORD		unusedPrimitive									; case 212
+DWORD		unusedPrimitive									; case 213
+DWORD		unusedPrimitive									; case 214
+DWORD		unusedPrimitive									; case 215
+DWORD		unusedPrimitive									; case 216
+DWORD		unusedPrimitive									; case 217
+DWORD		unusedPrimitive									; case 218
+DWORD		unusedPrimitive									; case 219
+DWORD		unusedPrimitive									; case 220
+DWORD		unusedPrimitive									; case 221
+DWORD		unusedPrimitive									; case 222
+DWORD		unusedPrimitive									; case 223
+DWORD		unusedPrimitive									; case 224
+
 
 IFDEF _DEBUG
 	_primitiveCounters DD	256 DUP (0)


### PR DESCRIPTION
Primitive support for ByteArray>>[s]qwordAtOffset: