### PR TITLE
Compiler reports float overflow/underflow when parsing float literals

### DIFF
--- a/Compiler/compiler.cpp
+++ b/Compiler/compiler.cpp
@@ -3492,23 +3492,11 @@ STDMETHODIMP_(POTE) Compiler::CompileForClass(IUnknown* piVM, Oop compilerOop, c
 		return Nil();
 
 	POTE resultPointer = Nil();
-	char* prevLocale = NULL;
 	int crtFlag;
 	__try
 	{
 		crtFlag = _CrtSetDbgFlag( _CRTDBG_REPORT_FLAG );
 		_CrtSetDbgFlag( crtFlag /*| _CRTDBG_CHECK_ALWAYS_DF */);
-		
-#ifdef USE_VM_DLL
-		prevLocale = setlocale(LC_ALL, NULL);
-		if (prevLocale[0] == 'C' && prevLocale[1] == 0)
-			prevLocale = NULL;
-		else
-		{
-			prevLocale = _strdup(prevLocale);
-			setlocale(LC_ALL, "C");
-		}
-#endif
 		
 		__try
 		{
@@ -3538,13 +3526,6 @@ STDMETHODIMP_(POTE) Compiler::CompileForClass(IUnknown* piVM, Oop compilerOop, c
 	}
 	__finally
 	{
-#ifdef USE_VM_DLL
-		if (prevLocale != NULL)
-		{
-			setlocale(LC_ALL, prevLocale);
-			free(prevLocale);
-		}
-#endif
 		_CrtSetDbgFlag(crtFlag);
 	}
 	

--- a/Compiler/lexer.cpp
+++ b/Compiler/lexer.cpp
@@ -44,10 +44,12 @@ Lexer::Lexer()
 	m_token = NULL;
 	m_tokenType = None;
 	tp = NULL;
+	m_locale = _create_locale(LC_ALL, "C");
 }
 
 Lexer::~Lexer()
 {
+	_free_locale(m_locale);
 	delete[] m_token;
 }
 
@@ -158,6 +160,19 @@ void Lexer::SkipComments()
 inline bool issign(char ch)
 {
 	return ch == '-' || ch == '+';
+}
+
+double Lexer::ThisTokenFloat() const
+{
+	_CRT_DOUBLE result;
+	int retval = _atodbl_l(&result, m_token, m_locale);
+	if (retval != 0)
+	{
+		// Most likely overflow or underflow. _atodbl will have set an appropriate continuation value
+		const_cast<Lexer*>(this)->CompileError((int)LErrBadNumber);
+	}
+
+	return result.x;
 }
 
 void Lexer::ScanFloat()

--- a/Compiler/lexer.h
+++ b/Compiler/lexer.h
@@ -190,6 +190,8 @@ private:
 	
 	TEXTRANGE m_thisTokenRange;
 	TEXTRANGE m_lastTokenRange;
+
+	_locale_t m_locale;
 };
 	
 ///////////////////////////////////////////////////////////////////////////////
@@ -213,11 +215,6 @@ inline const char* Lexer::ThisTokenText() const
 inline long Lexer::ThisTokenInteger() const
 {
 	return m_integer; 
-}
-
-inline double Lexer::ThisTokenFloat() const
-{
-	return atof(m_token);
 }
 
 inline bool Lexer::ThisTokenIsAssignment() const


### PR DESCRIPTION
Use _atodbl function that reports overflow/underflow when converting so can fire an appropriate compiler error notification.