### PR TITLE
Remove the 'at' caches

### DIFF
--- a/ExternalCall.asm
+++ b/ExternalCall.asm
@@ -134,7 +134,7 @@ primitiveVirtualCall PROC
 
 	; We must save down IP, as we're going to overwrite it, and because it may
 	; be required if a callback into Smalltalk results
-	StoreIPRegister
+	mov		[INSTRUCTIONPOINTER], _IP
 	
 	mov		eax, edx
 	neg		eax
@@ -251,7 +251,7 @@ asyncDLL32Call PROC STDCALL PUBLIC USES edi esi ebx,
 performCall:
 	push	eax												; ARG1: cached proc address
 	call	callExternalFunction
-	StoreSPRegister
+	mov		[STACKPOINTER], _SP		 						; Save down interpreter stack pointer, e.g. for C routine
 	ret														; eax will be non-zero as otherwise we'd not be here
 
 procAddressNotCached:
@@ -312,7 +312,8 @@ primitiveDLL32Call PROC
 
 	; We must save down IP/SP, as we're going to overwrite IP, and because they may
 	; be required if a callback into Smalltalk results
-	StoreInterpreterRegisters
+	mov		[INSTRUCTIONPOINTER], _IP
+	mov		[STACKPOINTER], _SP
 
 	push	0												; ARG6: Overlapped? (no)
 	push	OFFSET INTERPCONTEXT							; ARG5: Pointer to interpreters thread context

--- a/GCPrim.cpp
+++ b/GCPrim.cpp
@@ -71,7 +71,6 @@ void Interpreter::asyncGC(DWORD gcFlags)
 	}
 
 	resizeActiveProcess();
-	flushAtCaches();
 
 #ifdef _DEBUG
 	if (Interpreter::executionTrace != 0)

--- a/Interprt.h
+++ b/Interprt.h
@@ -718,11 +718,8 @@ public:
 		static void __fastcall debugMethodActivated(Oop* sp);
 		static void __fastcall debugReturnToMethod(Oop* sp);
 		static void checkStack(Oop* sp);
-
 		static void DumpMethodCacheStats();
-		static void DumpAtCacheStats();
 		static void DumpCacheStats();
-
 	#endif
 
 public:
@@ -747,25 +744,8 @@ private:
 
 	static MethodCacheEntry methodCache[MethodCacheSize];
 
-	__declspec(align(16)) struct AtCacheEntry
-	{
-		OTE*	oteArray;
-		MWORD	maxIndex;
-		void*	pElements;
-		int		type;
-	};
-
-	enum { AtCacheEntries = 16 };
-	enum { AtCacheMask = (AtCacheEntries - 1)*16 };
-	enum { AtCachePointers = 0, AtCacheBytes, AtCacheString };
-
-	static AtCacheEntry AtCache[AtCacheEntries];
-	static AtCacheEntry AtPutCache[AtCacheEntries];
-
 	static void flushCaches();
-	static void flushAtCaches();
 	static void initializeCaches();
-	static void purgeObjectFromCaches(OTE*);
 	
 	enum { FIXEDVMREFERENCES };
 	enum { SIGNALQGROWTH=32, SIGNALQSIZE=64 };

--- a/Interprt.inl
+++ b/Interprt.inl
@@ -182,19 +182,6 @@ inline void	Interpreter::NotifyAsyncPending()
 	InterlockedExchange(m_pbAsyncPending, TRUE);
 }
 
-#define ACEAt(cache,offset) (reinterpret_cast<AtCacheEntry*>(reinterpret_cast<BYTE*>(&cache[0])+atCacheOffset))
-
-inline void Interpreter::purgeObjectFromCaches(OTE* ote)
-{
-	unsigned atCacheOffset = Oop(ote) & Interpreter::AtCacheMask;
-	AtCacheEntry* ace = ACEAt(AtCache, atCacheOffset);
-	if (ace->oteArray == ote)
-		ace->oteArray = NULL;
-	ace = ACEAt(AtPutCache, atCacheOffset);
-	if (ace->oteArray == ote)
-		ace->oteArray = NULL;
-}
-
 inline void Interpreter::IncStackRefs(Oop* const sp)
 {
 	Process* pProcess = actualActiveProcess();

--- a/SnapshotPrim.cpp
+++ b/SnapshotPrim.cpp
@@ -72,9 +72,6 @@ Oop* __fastcall Interpreter::primitiveSnapshot(CompiledMethod&, unsigned argCoun
 	// load and the pool members, though not on the free list at present, are marked as free entries
 	// in the object table
 
-	// ZCT is reconciled, so objects may be deleted
-	flushAtCaches();
-
 	// Store the active frame of the active process before saving so available on image reload
 	// We're not actually suspending the process now, but it appears like that to the snapshotted
 	// image on restarting

--- a/bytecde.cpp
+++ b/bytecde.cpp
@@ -60,10 +60,6 @@ extern "C" void __fastcall callPrimitiveValue(unsigned, unsigned numArgs);
 	DWORD cacheHits = 0;
 	static DWORD cacheMisses = 0;
 
-	DWORD AtCacheHits = 0;
-	DWORD AtCacheMisses = 0;
-	DWORD AtPutCacheHits = 0;
-	DWORD AtPutCacheMisses = 0;
 #endif	
 
 //=============
@@ -815,60 +811,9 @@ MethodOTE* __fastcall Interpreter::lookupMethod(BehaviorOTE* classPointer, Symbo
 		cacheHits = cacheMisses = 0;
 	}
 
-	void Interpreter::DumpAtCacheStats()
-	{
-		// And also dump stats on the At cache
-		int used = 0;
-		for (int i=0;i<AtCacheEntries;i++)
-		{
-			if (AtCache[i].pElements != 0) 
-			{
-//				OTE* oteArray = AtCache[i].oteArray;
-//				TRACESTREAM << "AtCache[" << i << "] = " << oteArray << endl;
-				used++;
-			}
-		}
-
-		if (AtCacheHits != 0 || AtCacheMisses != 0)
-		{
-			char buf[256];
-			_snprintf(buf, sizeof(buf)-1, "%u At cache hits, %u misses %.2lf hit ratio, in use %d, empty %d\n",
-							AtCacheHits, AtCacheMisses, 
-							(double)AtCacheHits / 
-								(AtCacheHits + AtCacheMisses?AtCacheHits+AtCacheMisses:1),
-							used, AtCacheEntries - used);
-			OutputDebugString(buf);
-		}
-		AtCacheHits = AtCacheMisses = 0;
-		ZeroMemory(AtCache, sizeof(AtCache));
-
-		// Count used at:put: cache slots
-		{
-			used = 0;
-			for (int i=0;i<AtCacheEntries;i++)
-			{
-				if (AtPutCache[i].pElements != 0) used++;
-			}
-		}
-
-		if (AtPutCacheHits != 0 || AtPutCacheMisses != 0)
-		{
-			char buf[256];
-			_snprintf(buf, sizeof(buf)-1, "%u AtPut cache hits, %u misses %.2lf hit ratio, in use %d, empty %d\n",
-							AtPutCacheHits, AtPutCacheMisses, 
-							(double)AtPutCacheHits / 
-								(AtPutCacheHits + AtPutCacheMisses?AtPutCacheHits+AtPutCacheMisses:1),
-							used, AtCacheEntries - used);
-			OutputDebugString(buf);
-		}
-		AtPutCacheHits = AtPutCacheMisses = 0;
-		ZeroMemory(AtPutCache, sizeof(AtPutCache));
-	}
-
 	void Interpreter::DumpCacheStats()
 	{
 		DumpMethodCacheStats();
-		DumpAtCacheStats();
 	}
 #endif
 

--- a/interprt.cpp
+++ b/interprt.cpp
@@ -83,11 +83,6 @@ POTE* Interpreter::m_roots[] = {
 __declspec(align(16))
 Interpreter::MethodCacheEntry Interpreter::methodCache[MethodCacheSize];
 
-__declspec(align(16))
-Interpreter::AtCacheEntry Interpreter::AtCache[AtCacheEntries];
-__declspec(align(16))
-Interpreter::AtCacheEntry Interpreter::AtPutCache[AtCacheEntries];
-
 DWORD Interpreter::m_dwThreadId;
 HANDLE Interpreter::m_hThread;
 
@@ -277,13 +272,6 @@ inline void Interpreter::initializeCaches()
 	ASSERT(sizeof(OTE) == 16);
 	ASSERT(sizeof(MethodCacheEntry) == sizeof(OTE));
 	ASSERT(MethodCacheSize == 1024);
-
-	ASSERT(sizeof(AtCacheEntry) == sizeof(OTE));
-
-	// Caches should be 16-byte aligned
-	ASSERT(((intptr_t)methodCache & 0xF) == 0);
-	ASSERT(((intptr_t)AtCache & 0xF) == 0);
-	ASSERT(((intptr_t)AtPutCache & 0xF) == 0);
 
 	flushCaches();
 }

--- a/istasm.inc
+++ b/istasm.inc
@@ -71,28 +71,6 @@ OTE		ENDS
 
 POTE		TYPEDEF 	PTR OTE
 
-AtCacheEntry STRUCT 2t
-	oteArray	POTE	?
-	maxIndex	DWORD	?
-	pElements	DWORD	?
-	elemType	DWORD	?
-AtCacheEntry ENDS
-
-_AtCache EQU ?AtCache@Interpreter@@0PAUAtCacheEntry@1@A
-extern _AtCache:AtCacheEntry
-
-_AtPutCache EQU ?AtPutCache@Interpreter@@0PAUAtCacheEntry@1@A
-extern _AtPutCache:AtCacheEntry
-
-AtCacheEntries EQU 16
-; This is right for 4 word OTEs and four word ACEs
-AtCacheMask EQU	((AtCacheEntries-1)*16)
-
-; The types of objects stored in the AtCache
-AtCachePointers EQU 0
-AtCacheBytes EQU 1
-AtCacheString EQU 2
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Shared pointers (shared between VM and Smalltalk code)
 
@@ -595,73 +573,15 @@ CountUpOopIn MACRO oopRegLetter	;; , countRegLetter
 	fini:
 ENDM
 
-
-StoreIPRegister MACRO
-	mov		[INSTRUCTIONPOINTER], _IP		;; Ditto the instruction pointer
-ENDM
-
-StoreSPRegister MACRO spReg
-	mov		[STACKPOINTER], _SP		 		;; Save down interpreter stack pointer, e.g. for C routine
-ENDM
-
-; Store down the commonly used Interpreter registers from Assembler to C++
-StoreInterpreterRegisters MACRO
-	StoreIPRegister
-	StoreSPRegister
-ENDM
-
-LoadIPRegister MACRO
-	mov		_IP, [INSTRUCTIONPOINTER]
-ENDM
-
-LoadSPRegister MACRO
-	mov		_SP, [STACKPOINTER]
-ENDM
-
-LoadBPRegister MACRO
-	mov		_BP, [BASEPOINTER]
-ENDM
-
-LoadIPSPRegisters MACRO
-	LoadIPRegister
-	LoadSPRegister
-ENDM
-
-; Load all interpreter registers on entering assembler from C++, or on return from C++
-; code which modifies the context
-LoadInterpreterRegisters MACRO
-	LoadIPSPRegisters
-	LoadBPRegister
-ENDM
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Stack accessing and manipulation macros
-
-LoadStackValueInto	MACRO	offset, register
-	mov register, [_SP-(OOPSIZE*offset)]
-ENDM
-
-UnPop MACRO
-	add		_SP, OOPSIZE			; Unpop
-ENDM
-
-PopStack MACRO count:=<1>
-	sub		_SP, count&*OOPSIZE
-ENDM
-
-; Macro to pop top stack element and nil it out. Does no ref. counting
-PopOopInto MACRO register
-	mov		register, [_SP]						;; Load stack top into register
-	sub		_SP, OOPSIZE
-ENDM
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 CallCPP MACRO mangledName
-	StoreInterpreterRegisters
+	mov		[INSTRUCTIONPOINTER], _IP
+	mov		[STACKPOINTER], _SP
 	call	mangledName
-	LoadInterpreterRegisters
-
+	mov		_IP, [INSTRUCTIONPOINTER]
+	mov		_SP, [STACKPOINTER]
+	mov		_BP, [BASEPOINTER]
 ENDM
 
 RECONCILEZCT EQU ?ReconcileZct@ObjectMemory@@SIPAIXZ

--- a/objmem.cpp
+++ b/objmem.cpp
@@ -113,7 +113,6 @@ void __fastcall ObjectMemory::oneWayBecome(OTE* ote1, OTE* ote2)
 	// that are in the stack but are otherwise unreferenced)
 	ote1->m_count = 1;
 	ote1->countDown();
-	Interpreter::flushAtCaches();
 
 	CHECKREFERENCES
 }

--- a/primitiv.cpp
+++ b/primitiv.cpp
@@ -155,9 +155,6 @@ Oop* __fastcall Interpreter::primitiveResize()
 		ASSERT(pNew != NULL || newSize == 0);
 	}
 
-	// Object size has changed, invalidating any AtCache entry
-	purgeObjectFromCaches(oteReceiver);
-
 	return primitiveSuccess(1);
 }
 
@@ -205,17 +202,6 @@ void Interpreter::flushCaches()
 #endif
 
 	ZeroMemory(methodCache, sizeof(methodCache));
-
-	flushAtCaches();
-}
-
-void Interpreter::flushAtCaches()
-{
-#ifdef _DEBUG
-	//DumpAtCacheStats();
-#endif
-	ZeroMemory(AtCache, sizeof(AtCache));
-	ZeroMemory(AtPutCache, sizeof(AtPutCache));
 }
 
 Oop* __fastcall Interpreter::primitiveFlushCache()

--- a/process.cpp
+++ b/process.cpp
@@ -678,10 +678,6 @@ void Interpreter::switchTo(ProcessOTE* oteProcess)
 		}
 #endif
 
-		// Reconciling the ZCT will result in objects being deleted, so these should be removed from
-		// the At Caches.
-		flushAtCaches();
-
 		// Important to get the real active process here
 		ObjectMemory::storePointerWithValue(reinterpret_cast<POTE&>(scheduler()->m_activeProcess), reinterpret_cast<POTE>(oteProcess));
 		m_registers.NewActiveProcess(oteProcess);

--- a/realloc.cpp
+++ b/realloc.cpp
@@ -269,8 +269,6 @@ VariantObject* ObjectMemory::resize(PointersOTE* ote, MWORD newPointers, bool bR
 //		pNewBody = resize(reinterpret_cast<BytesOTE*>(ote), newSize);
 //	}
 //
-//	// The AtCaches could have been invalidated by the change of size of the object
-//	Interpreter::purgeObjectFromCaches(ote);
 //	return pNewBody;
 //}
 

--- a/zct.cpp
+++ b/zct.cpp
@@ -120,8 +120,6 @@ Oop* ObjectMemory::ReconcileZct()
 	const int nOldZctEntries = m_nZctEntries;
 #endif
 
-	Interpreter::flushAtCaches();
-
 	Oop* const sp = Interpreter::m_registers.m_stackPointer;
 
 	EmptyZct(sp);


### PR DESCRIPTION
The at/atput caches are small caches of data about a few recently accessed
objects that allow shortcutting of normal primitive invocation for
element-by-element access through the #at: and #at:put: messages. When
implemented the overhead of maintaining these was fairly small, but in the
current VM they are flushed very frequently. It turns out that the main
beneficial effect of these is when accessing Arrays, and optimising for
these can be achieved much more simply. There might be some benefit in
also optimising for ByteArray.